### PR TITLE
Update HMS hodo parameters for 4/4 trigger

### DIFF
--- a/PARAM/HMS/HODO/hhodo_3of4trigger.param
+++ b/PARAM/HMS/HODO/hhodo_3of4trigger.param
@@ -8,7 +8,7 @@ hhodo_adc_mode=1
 ; 
 ; hhodo_tdc_offset is array of time offsets for all paddles in a plane
 ;   to move the tdc to between 0 and 4000 channels.
-  hhodo_tdc_offset = 1280, 1280, 1280, 1290
+  hhodo_tdc_offset = 1050, 1050, 1050, 1050
 ; hstart_time_center  center of allowed time window (ns)
    hstart_time_center = 32.                                                     
 ; hstart_time_slop    1/2 width of time window                                  

--- a/PARAM/HMS/HODO/hhodo_4of4trigger.param
+++ b/PARAM/HMS/HODO/hhodo_4of4trigger.param
@@ -1,3 +1,4 @@
+hcosmicflag=1
 ; for now manually set hte FADC mode
 ;  1 == Use the pulse int - pulse ped
 ;  2 == Use the sample integral - known ped
@@ -7,7 +8,7 @@ hhodo_adc_mode=1
 ; 
 ; hhodo_tdc_offset is array of time offsets for all paddles in a plane
 ;   to move the tdc to between 0 and 4000 channels.
-  hhodo_tdc_offset = 1300, 1300, 1300, 1300
+  hhodo_tdc_offset = 1280, 1280, 1280, 1290
 ; hstart_time_center  center of allowed time window (ns)
    hstart_time_center = 32.                                                     
 ; hstart_time_slop    1/2 width of time window                                  


### PR DESCRIPTION
The 4/4 trigger is about 23ns different than the 3/4 trigger
So need different hhodo_tdc_offset parameters
Updated the hhodo_4of4trigger.param to have better hhodo_tdc_offset parameters