### PR TITLE
Fix mistake in PARAM/SHMS/HODO/phodo.pos

### DIFF
--- a/PARAM/SHMS/HODO/phodo.pos
+++ b/PARAM/SHMS/HODO/phodo.pos
@@ -58,7 +58,7 @@ phodo_plane_names = "1x 1y 2x 2y"
                         35.
                         42. 
       pscin_2x_left  =  55.
-      pscin_2x_right =  55.
+      pscin_2x_right =  -55.
       pscin_2x_offset=  0.0
       pscin_2x_center=  -58.5
                         -49.5


### PR DESCRIPTION
pscin_2x_right needed a minus sign.
pscin_2x_right was + 55 and
pscin_2x_left was +55.