### PR TITLE
-Added new parameter file that has debug flag ON (for SHMS H.G.Cerenkov,

### DIFF
--- a/DEF-files/SHMS/HGCER/phgcerana.def
+++ b/DEF-files/SHMS/HGCER/phgcerana.def
@@ -3,13 +3,31 @@
 block P.hgcer.*
 block T.shms.*
 
-TH1F phgcer_occu 'SHMS Heavy Gas Cherenkov Occupancy; Counter Number; Number of Entries' P.hgcer.adcCounter 4 0.5 4.5
+#TH1F phgcer_occu 'SHMS Heavy Gas Cherenkov Occupancy; Counter Number; Number of Entries' P.hgcer.adcCounter 4 0.5 4.5
+#TH1F phgcer_adcErrFlg 'SHMS Heavy Gas Cherenkov Error Flag for When FPGA Fails; Error Flag; Number of Entries' P.hgcer.adcErrorFlag 22 0.0 1.1
 
+#1D HISTOS
+TH1F phgcer_goodadchits 'SHMS Heavy Gas Cherenkov Number of Good ADC Hits Per PMT; Number of Good ADC Hits / PMT; Number of Entries' P.hgcer.numGoodAdcHits 4 0.5 4.5
+TH1F phgcer_tot_goodadchits 'SHMS Heavy Gas Cherenkov Total Number of ADC Hits; Total Number of ADC Hits; Number of Entries' P.hgcer.totNumGoodAdcHits 4 0.5 4.5
+
+#2D HISTOS
+TH2F phgcer_goodped_vs_cntr 'SHMS Heavy Gas Cherenkov Good Pulse Pedestal vs. Counter Number; Counter Number; Raw Pulse Pedestal / 10 ADC Units' P.hgcer.adcCounter P.hgcer.goodAdcPed 4 0.5 4.5 1000 0 10000
+TH2F phgcer_goodpi_vs_cntr 'SHMS Heavy Gas Cherenkov Good Pulse Integral vs. Counter Number; Counter Number; Raw Pulse Integral / 10 ADC Units' P.hgcer.adcCounter P.hgcer.goodAdcPulseInt 4 0.5 4.5 4000 0 40000
+TH2F phgcer_goodrawpi_vs_cntr 'SHMS Heavy Gas Cherenkov Good Raw Pulse Integral vs. Counter Number; Counter Number; Raw Pulse Integral / 10 ADC Units' P.hgcer.adcCounter P.hgcer.goodAdcPulseIntRaw 4 0.5 4.5 4000 0 40000
+TH2F phgcer_goodamp_vs_cntr 'SHMS Heavy Gas Cherenkov Good Pulse Amplitude vs. Counter Number; Counter Number; Raw Pulse Amplitude / 10 ADC Units' P.hgcer.adcCounter P.hgcer.goodAdcPulseAmp 4 0.5 4.5 410 0 4100
+TH2F phgcer_goodptime_vs_cntr 'SHMS Heavy Gas Cherenkov Good Pulse Time vs. Counter Number; Counter Number;  Raw Pulse Time / 10 ADC Units' P.hgcer.adcCounter P.hgcer.goodAdcPulseTime 4 0.5 4.5 1000 0 10000
+
+
+#1D Histos for Debugging 
+TH1F phgcer_adchits 'SHMS Heavy Gas Cherenkov ADC Hits Per PMT; Number of ADC Hits / PMT; Number of Entries' P.hgcer.numAdcHits 4 0.5 4.5
+TH1F phgcer_tot_adchits 'SHMS Heavy Gas Cherenkov Total Number of ADC Hits; Total Number of ADC Hits; Number of Entries' P.hgcer.totNumAdcHits 4 0.5 4.5
+
+#2d Histos for Debugging 
 TH2F phgcer_rawped_vs_cntr 'SHMS Heavy Gas Cherenkov Raw Pulse Pedestal vs. Counter Number; Counter Number; Raw Pulse Pedestal / 10 ADC Units' P.hgcer.adcCounter P.hgcer.adcPedRaw 4 0.5 4.5 1000 0 10000
 TH2F phgcer_rawpi_vs_cntr 'SHMS Heavy Gas Cherenkov Raw Pulse Integral vs. Counter Number; Counter Number; Raw Pulse Integral / 10 ADC Units' P.hgcer.adcCounter P.hgcer.adcPulseIntRaw 4 0.5 4.5 4000 0 40000
 TH2F phgcer_rawamp_vs_cntr 'SHMS Heavy Gas Cherenkov Raw Pulse Amplitude vs. Counter Number; Counter Number; Raw Pulse Amplitude / 10 ADC Units' P.hgcer.adcCounter P.hgcer.adcPulseAmpRaw 4 0.5 4.5 410 0 4100
 TH2F phgcer_rawptime_vs_cntr 'SHMS Heavy Gas Cherenkov Raw Pulse Time vs. Counter Number; Counter Number;  Raw Pulse Time / 10 ADC Units' P.hgcer.adcCounter P.hgcer.adcPulseTimeRaw 4 0.5 4.5 1000 0 10000
-
 TH2F phgcer_ped_vs_cntr 'SHMS Heavy Gas Cherenkov Pulse Pedestal vs. Counter Number; Counter Number;  Pulse Pedestal / 1 ADC Units' P.hgcer.adcCounter P.hgcer.adcPed 4 0.5 4.5 1000 0 1000
 TH2F phgcer_pi_vs_cntr 'SHMS Heavy Gas Cherenkov Pulse Integral vs. Counter Number; Counter Number;  Pulse Integral / 10 ADC Units' P.hgcer.adcCounter P.hgcer.adcPulseInt 4 0.5 4.5 4000 0 40000
 TH2F phgcer_amp_vs_cntr 'SHMS Heavy Gas Cherenkov Pulse Amplitude vs. Counter Number; Counter Number;  Pulse Amplitude / 1 ADC Units' P.hgcer.adcCounter P.hgcer.adcPulseAmp 4 0.5 4.5 4100 0 4100
+

--- a/PARAM/SHMS/GEN/p_fadc_debug.param
+++ b/PARAM/SHMS/GEN/p_fadc_debug.param
@@ -1,0 +1,1 @@
+phgcer_debug_adc = 1

--- a/SCRIPTS/SHMS/replay_phgcer_test_stand.C
+++ b/SCRIPTS/SHMS/replay_phgcer_test_stand.C
@@ -31,7 +31,7 @@ void replay_phgcer_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
 
   // Load params for HMS trigger configuration
   gHcParms->Load("PARAM/TRIG/tshms.param");
-
+  gHcParms->Load("PARAM/SHMS/GEN/p_fadc_debug.param");
   // Load the Hall C style detector map
   gHcDetectorMap = new THcDetectorMap();
   gHcDetectorMap->Load("MAPS/SHMS/DETEC/phgcer_ptrig.map");


### PR DESCRIPTION
so far). This flag will add histograms that fall under the 'debug'
category from the source code.
-Loaded the fadc_debug parameter file to the test stand replay scripts (for
SHMS H.G.Cerenkov so far), to be used by experts ONLY.
-Added new 1D and 2D Histograms to the DEF files for SHMS H.G.Cerenkov so far.