### PR TITLE
Files:             Changes Made:

### DIFF
--- a/CALIBRATION/shms_dc_calib/run_Cal.C
+++ b/CALIBRATION/shms_dc_calib/run_Cal.C
@@ -1,8 +1,11 @@
 //SCRIPT TO RUN OVER ALL HMS DC CALIBRATION SCRIPTS AT ONCE, AND UPDATE THE
 //NECESSARY PARAMTER FILES hdriftmap.param and  hdc.param
+
+
+using namespace std;
 void run_Cal()
 {
-      
+  
   //User Input Run
   int run_NUM;
   cout << "Enter Run Number: " << endl;
@@ -13,25 +16,26 @@ void run_Cal()
   fout.open("scripts/input_RUN.txt");
   fout << run_NUM << endl;
   fout.close();
-
+  
 
   //Create root and data files Directories if they dont exist
-  char *dir_root = "mkdir ./root_files/";
-  char *dir_data = "mkdir ./data_files/";
+  const char *dir_root = "mkdir ./root_files/";
+  const char *dir_data = "mkdir ./data_files/";
 
-  if (system(dir_root || dir_data) != 0) {
+  // if (std::system(dir_root || dir_data) != 0) {
     system(dir_root);
     system(dir_data);
-  }
+    // }
 
+  
   //Create run Directories if they dont exist
   char *dir0 = Form("mkdir ./root_files/run%d", run_NUM);
   char *dir1 = Form("mkdir ./data_files/run%d", run_NUM);
 
-  if (system(dir0 || dir1) != 0) {
+  //if (system(dir0 || dir1) != 0) {
     system(dir0);
     system(dir1);
-  }
+    // }
 
   
 
@@ -48,21 +52,21 @@ void run_Cal()
   
   
 
-gSystem->cd("./scripts");
+  gSystem->cd("./scripts");
 
   
   //execute code to get t0 from each wire in each plane
   gSystem->Exec("root -l -q -b get_wire_tzero.C");
  
   //execute code to update pdc parameter file
-  gSystem->Exec("root -l -q update_pdcparam.C");
+  // gSystem->Exec("root -l -q update_pdcparam.C");
 
   //execute code to get t0 corrected drift times
   gSystem->Exec("root -l -q get_pdc_time_histo_tzero_corrected.C");
   
  //execute code to update LookUp Table
   gSystem->Exec("root -l -q get_LookUp_Values.C");
-
-  
   
 }
+  
+

--- a/CALIBRATION/shms_dc_calib/scripts/get_LookUp_Values.C
+++ b/CALIBRATION/shms_dc_calib/scripts/get_LookUp_Values.C
@@ -98,7 +98,7 @@ void get_LookUp_Values() {
       lookup_value[ip] = binSUM[ip] / binContent_TOTAL[ip];
       bin_count = bin_count + 1;
      
-      if (bin_count < = 8 ) {
+      if (bin_count <= 8 ) {
 	ofs << setprecision(5) << lookup_value[ip] << fixed << ",";
       }
      

--- a/CALIBRATION/shms_dc_calib/scripts/get_pdc_time_histo.C
+++ b/CALIBRATION/shms_dc_calib/scripts/get_pdc_time_histo.C
@@ -14,14 +14,16 @@ void get_pdc_time_histo()
 
   TString file_name = "../../../ROOTfiles/shms_replay_%d.root";
 
+  /*
   //Create RUN Directories if they dont exist
-  char *dir0 = Form("mkdir -p ../root_files/run%d", run_NUM);
+    char *dir0 = Form("mkdir -p ../root_files/run%d", run_NUM);
   char *dir1 = Form("mkdir -p ../data_files/run%d", run_NUM);
 
   if (system(dir0 || dir1) != 0) {
     system(dir0);
     system(dir1);
   }
+  */
 
   //open file
   TFile *f = new TFile(Form(file_name.Data(), run_NUM), "READ");

--- a/CALIBRATION/shms_dc_calib/scripts/get_wire_tzero.C
+++ b/CALIBRATION/shms_dc_calib/scripts/get_wire_tzero.C
@@ -5,7 +5,7 @@
 a certain number of bins and this fit is extrapolated to y=0(x-axis). The extrapolated value is take to be t0*/
 
 #include <vector>
-#include <TMath>
+#include "TMath.h"
 
 #define NPLANES 12
 
@@ -34,7 +34,7 @@ void get_wire_tzero()
  TString root_file;
  TFile *f[NPLANES];
    
- int total_wires;  //integer to store total sense wires for a plane chosen by the user
+ // int total_wires;  //integer to store total sense wires for a plane chosen by the user
         
  //Loop over all planes
  for (int ip = 0; ip < NPLANES; ip++){
@@ -57,40 +57,61 @@ void get_wire_tzero()
 
    f[ip]->cd();  //change to file containing the wire drift times histos
  
-   int total_wires;  //integer to store total sense wires for a plane chosen by the user
-   
+   //   int total_wires;  //integer to store total sense wires for a plane chosen by the user
+
+   //INITIALIZE VARIABLES
+   int total_wires;
+   int sensewire;
+   TH1F *cell_dt[107];
+   Int_t *bin_max;
+   Int_t *bin_maxContent;
+   Double_t *time_max;
+   Double_t *twenty_perc_maxContent;
+   Double_t *ref_time;
+
+
+
+     //Declarations
+     int time_init;           //start fit value 
+     int time_final;          //end fit value
+     int t_zero;
+     int entries;             //entries for each wire
+     
+     double m;                //slope
+     double y_int;            //y-intercept
+     double m_err;
+     double y_int_err;
+     double t_zero_err;
+
    //Set variables depending on which plane is being studied
    if(ip == 0 || ip == 1 || ip == 4 || ip == 5 || ip == 6 || ip == 7 || ip == 10 || ip == 11) {
-     TH1F *cell_dt[107]; //declare array of histos to store drift times     
+     //declare array of histos to store drift times     
      total_wires=107; 
 
      //Declare bin properties for given sense wires in a plane
 
-     int bin_max[107];                    /*Array to store the bin number corresponding to the drift time distribution peak*/
-     int bin_maxContent[107];             /*Array to store the content (# events) corresponding to the bin with maximum content*/
-     double time_max[107];                /*Array to store the x-axis(drift time (ns)) corresponding to bin_max*/
-     double twenty_perc_maxContent[107];  /*Array to store 20% of maximum bin content (peak)*/						     
-     double ref_time[107];               /*Array to store reference times for each sense wire*/
+     bin_max = new Int_t[total_wires];                    /*Array to store the bin number corresponding to the drift time distribution peak*/
+     bin_maxContent= new Int_t[total_wires];             /*Array to store the content (# events) corresponding to the bin with maximum content*/
+     time_max= new Double_t[total_wires];                /*Array to store the x-axis(drift time (ns)) corresponding to bin_max*/
+     twenty_perc_maxContent= new Double_t[total_wires];  /*Array to store 20% of maximum bin content (peak)*/						     
+     ref_time= new Double_t[total_wires];               /*Array to store reference times for each sense wire*/
 
    }
-
-   else if(ip == 2 || ip == 3 || ip == 8 || ip == 9) {
-     TH1F *cell_dt[79];
-     total_wires=79;      
    
-     int bin_max[79];                                 
-     int bin_maxContent[79];                           
-     double time_max[79];                               
-     double twenty_perc_maxContent[79];                
-     double ref_time[79];          
-
+   else if(ip == 2 || ip == 3 || ip == 8 || ip == 9) {
+     total_wires=79;      
+     bin_max = new Int_t[total_wires];                               
+     bin_maxContent= new Int_t[total_wires]; 
+     time_max= new Double_t[total_wires];
+     twenty_perc_maxContent= new Double_t[total_wires];
+     ref_time= new Double_t[total_wires];
    }	   
    
  	
    /*Get wire histos from root file and loop over each 
      sense wire of a plane in shms Drift Chambers (DC1 or DC2)*/
  
-   for (int sensewire=1; sensewire<=total_wires; sensewire++){
+   for (sensewire=1; sensewire<=total_wires; sensewire++){
 
      //Get title of histos in root file
      TString drift_time_histo = Form("wire_%d", sensewire); 
@@ -153,7 +174,7 @@ void get_wire_tzero()
 	 // Loop over 2 bin contents stored in array content
 	 for (j=0; j<2; j++){
 	   
-	   if(content[j] > =  twenty_perc_maxContent[sensewire-1]){
+	   if(content[j] >=  twenty_perc_maxContent[sensewire-1]){
 	     counts = counts+1;
              
 	     if(counts >= 2) { goto stop;}
@@ -184,17 +205,7 @@ void get_wire_tzero()
      //*******Extract the "t0" Using a Fitting Procedure********//
      //*********************************************************//
      
-     //Declarations
-     int time_init;           //start fit value 
-     int time_final;          //end fit value
-     int t_zero;
-     int entries;             //entries for each wire
-     
-     double m;                //slope
-     double y_int;            //y-intercept
-     double m_err;
-     double y_int_err;
-     double t_zero_err;
+
      
      //Get time corresponding to bin (fit range) 
      time_init = cell_dt[sensewire-1] -> GetXaxis() -> GetBinCenter(bin_num[0]-5); //choose bin range over which to fit

--- a/CALIBRATION/shms_dc_calib/scripts/wire_drift_times.C
+++ b/CALIBRATION/shms_dc_calib/scripts/wire_drift_times.C
@@ -66,6 +66,9 @@ void wire_drift_times::Loop()
 	
     //If specific planes are encountered, treat them as follows:
 
+    //variable declarations
+    int wirenum;
+
     /*PLANE 1U1, 1V1, 2U1, 2V1*/				
     //If specific planes are encountered, treat them as follows:
     if(ip == 0 || ip == 1 || ip == 4 || ip == 5 || ip == 6 || ip == 7 || ip == 10 || ip == 11) {
@@ -74,7 +77,7 @@ void wire_drift_times::Loop()
       TH2F *wire_vs_dt = new TH2F("wire_vs_dt", "", 200., -50., 350., 107., 0.,107.);
     
       //Initialize wire drift time histograms
-      for (int wirenum=1; wirenum<=total_wires_uv; wirenum++){
+      for (wirenum=1; wirenum<=total_wires_uv; wirenum++){
 	cell_dt[wirenum-1] = new TH1F(Form("wire_%d", wirenum), "", 200., -50., 350.);
       }
 	


### PR DESCRIPTION
run_Cal.C          commented out some boolean statements producing
                   that were producing a compilaton error. Commented out
                   execution of script update_pdcparam.C, as it is obsolete,
                   since we will be using a new paramerer file containing
                   individual wire tzero.

get_pdc_time_histo.C  commented out obsolete lines that created some directories

wire_drift_times.C  declared 'wirenum' variable outside of loop to solve the
                    "use of undeclared identifier" compilation error

get_wire_tzero.C    moved several variable declarations outside the loop
		    over sensewires to solve  "use of undeclared identifier"
		    compilation error

get_LookUp_Values.C minor syntax error fix.