### PR TITLE
Update PARAM files for hodo calibration

### DIFF
--- a/CALIBRATION/hodo_calib/README.md
+++ b/CALIBRATION/hodo_calib/README.md
@@ -19,10 +19,10 @@ Compiling code
 
 Running code
 -----------
-* First replay data with either
-** HMS:   gHcParms->Load("PARAM/HMS/HODO/htofcal.param");
-** SHMS:   gHcParms->Load("PARAM/HMS/HODO/ptofcal.param");
-* The replay should put the new file : hfort.37 or pfort.37 in the CALIBRATION/hodo_calib directory
+* First replay data by adding  either line to replay script
+** HMS:   gHcParms->Load("PARAM/HMS/HODO/CALIB/htofcal.param");
+** SHMS:   gHcParms->Load("PARAM/SHMS/HODO/CALIB/ptofcal.param");
+* The replay will put the new file : hfort.37 or pfort.37 in the CALIBRATION/hodo_calib directory
 * Copy either hmstofcal.inp or shmstofcal.inp to tofcal.inp
 * Execute ./tofcal
 * Print out info on the initial chi2 of  data and final chi2 of the fit.

--- a/PARAM/HMS/HODO/CALIB/KPP_Spring_2017/hhodo_calib_303.param
+++ b/PARAM/HMS/HODO/CALIB/KPP_Spring_2017/hhodo_calib_303.param
@@ -1,7 +1,5 @@
 ;HMS Hodo Calibration paramters
 
-hdumptof=1
-hdumptof_filename="CALIBRATION/hodo_calib/hfort.37"
  
 ; new param from KPP HMS run 303                 
 hhodo_pos_invadc_offset =   -0.00,   -0.00,   -0.70,   -0.00

--- a/PARAM/HMS/HODO/CALIB/hhodo_calib.param
+++ b/PARAM/HMS/HODO/CALIB/hhodo_calib.param
@@ -1,8 +1,5 @@
 ;HMS Hodo Calibration paramters
 
-hdumptof=1
-hdumptof_filename="CALIBRATION/hodo_calib/hfort.37"
-
 hhodo_pos_invadc_offset = 0.000,   0.0000,  0.000,   0.000
  0.000,   0.0000,  0.000,   0.000
  0.000,   0.0000,  0.000,   0.000

--- a/PARAM/HMS/HODO/CALIB/htofcalib.param
+++ b/PARAM/HMS/HODO/CALIB/htofcalib.param
@@ -1,0 +1,3 @@
+; set hdumptof =1 to write out the calibration file
+hdumptof=1
+hdumptof_filename="CALIBRATION/hodo_calib/hfort.37"

--- a/PARAM/SHMS/HODO/CALIB/phodo_calib.param
+++ b/PARAM/SHMS/HODO/CALIB/phodo_calib.param
@@ -1,5 +1,3 @@
-pdumptof = 1
-pdumptof_filename = "CALIBRATION/hodo_calib/pfort.37"
 
 phodo_pos_invadc_offset =   -5.0000,   -5.0000,  0.000,   0.000
 			    -5.0000,   -2.0000,  0.000,   0.000

--- a/PARAM/SHMS/HODO/CALIB/ptofcalib.param
+++ b/PARAM/SHMS/HODO/CALIB/ptofcalib.param
@@ -1,0 +1,3 @@
+; set pdumptof =1 to write out the calibration file
+pdumptof = 0
+pdumptof_filename = "CALIBRATION/hodo_calib/pfort.37"


### PR DESCRIPTION
Create two files
htofcalib.param
ptofcalib.param

Each of these files sets the flag to dump the tof calibration
data to a file that is designated in the file.
The user has to add a line
gHcParms->Load("PARAM/HMS/HODO/htofcal.param");

or

gHcParms->Load("PARAM/SHMS/HODO/ptofcal.param");
to the replay script to get the  data files for hodo calibration

Remove these parameters from the regular hodo calibration files.