### PR TITLE
added HODO EDTM to Maps and Param filrs for HMS/SHMS; Added block T.h…

### DIFF
--- a/DEF-files/HMS/EPICS/epics_short.def
+++ b/DEF-files/HMS/EPICS/epics_short.def
@@ -1,5 +1,4 @@
-# See $ANALYZER/examples/output_example.def for examples
-
+block T.hms.*
 
 begin epics
 IBC3H00CRCUR4

--- a/MAPS/COIN/DETEC/TRIG/cointrig.map
+++ b/MAPS/COIN/DETEC/TRIG/cointrig.map
@@ -46,7 +46,7 @@ REFINDEX=0
     11,       2,     12,     1!  hPSHWRLO
     12,       2,     13,     1!  hPSHWRHI
     13,       2,     14,     1!  hSHWR
-    14,       2,     15,     1!  hAERSUM
+    14,       2,     15,     1!  hHODO_EDTM
     15,       2,     16,     1!  hCERSUM
 !CAEN1190 module
 SLOT=20
@@ -102,6 +102,7 @@ REFINDEX=0
   39,   2,  10,   1  ! pAERSUM
   40,   2,  11,   1  ! pHGCERSUM
   41,   2,  12,   1  ! pNGCERSUM
+  42,   2,  23,   1  ! pHODO_EDTM
 
 ROC=6
 

--- a/MAPS/HMS/DETEC/AERO/haero_htrig.map
+++ b/MAPS/HMS/DETEC/AERO/haero_htrig.map
@@ -32,7 +32,7 @@ REFINDEX=0
   11,   2,  12,   1  ! hPSHWRLO
   12,   2,  13,   1  ! hPSHWRHI
   13,   2,  14,   1  ! hSHWR
-  14,   2,  15,   1  ! hAERSUM
+  14,   2,  15,   1  ! hHODO_EDTM
   15,   2,  16,   1  ! hCERSUM
 
 SLOT=20

--- a/MAPS/HMS/DETEC/CAL/hcal_htrig.map
+++ b/MAPS/HMS/DETEC/CAL/hcal_htrig.map
@@ -32,7 +32,7 @@ REFINDEX=0
   11,   2,  12,   1  ! hPSHWRLO
   12,   2,  13,   1  ! hPSHWRHI
   13,   2,  14,   1  ! hSHWR
-  14,   2,  15,   1  ! hAERSUM
+  14,   2,  15,   1  ! hHODO_EDTM
   15,   2,  16,   1  ! hCERSUM
 
 SLOT=20

--- a/MAPS/HMS/DETEC/CER/hcer_htrig.map
+++ b/MAPS/HMS/DETEC/CER/hcer_htrig.map
@@ -32,7 +32,7 @@ REFINDEX=0
   11,   2,  12,   1  ! hPSHWRLO
   12,   2,  13,   1  ! hPSHWRHI
   13,   2,  14,   1  ! hSHWR
-  14,   2,  15,   1  ! hAERSUM
+  14,   2,  15,   1  ! hHODO_EDTM
   15,   2,  16,   1  ! hCERSUM
 
 SLOT=20

--- a/MAPS/HMS/DETEC/STACK/hms_stack.map
+++ b/MAPS/HMS/DETEC/STACK/hms_stack.map
@@ -43,7 +43,7 @@ REFINDEX=0
   11,   2,  12,   1  ! hPSHWRLO
   12,   2,  13,   1  ! hPSHWRHI
   13,   2,  14,   1  ! hSHWR
-  14,   2,  15,   1  ! hAERSUM
+  14,   2,  15,   1  ! hHODO_EDTM
   15,   2,  16,   1  ! hCERSUM
 
 SLOT=20

--- a/MAPS/HMS/DETEC/TRIG/htrig.map
+++ b/MAPS/HMS/DETEC/TRIG/htrig.map
@@ -46,7 +46,7 @@ REFINDEX=0
     11,       2,     12,     1!  hPSHWRLO
     12,       2,     13,     1!  hPSHWRHI
     13,       2,     14,     1!  hSHWR
-    14,       2,     15,     1!  hAERSUM
+    14,       2,     15,     1!  hHODO_EDTM
     15,       2,     16,     1!  hCERSUM
 !CAEN1190 module
 SLOT=20

--- a/MAPS/SCALERS/db_HScalevt.dat
+++ b/MAPS/SCALERS/db_HScalevt.dat
@@ -15,6 +15,8 @@ variable 3 19 1 .hod.2y7.negScaler HMS 2Y- paddle 7
 variable 3 19 2 .hod.2y7.negScalerRate HMS 2Y- paddle 7
 variable 2 22 1 .hod.2x6.negScaler HMS 2X- paddle 6
 variable 2 22 2 .hod.2x6.negScalerRate HMS 2X- paddle 6
+variable 6 5 1 .h2Xh2Y.scaler HMS S2T
+variable 6 5 2 .h2Xh2Y.scalerRate HMS S2T
 variable 2 6 1 .hod.2x6.posScaler HMS 2X+ paddle 6
 variable 2 6 2 .hod.2x6.posScalerRate HMS 2X+ paddle 6
 variable 2 27 1 .hod.2x15.negScaler HMS 2X- paddle 15
@@ -37,12 +39,16 @@ variable 6 11 1 .PSHWRLO.scaler HMS PSHWRLO
 variable 6 11 2 .PSHWRLO.scalerRate HMS PSHWRLO
 variable 1 4 1 .hod.1y2.posScaler HMS 1Y+ paddle 2
 variable 1 4 2 .hod.1y2.posScalerRate HMS 1Y+ paddle 2
+variable 6 4 1 .h1Xh1Y.scaler HMS S1T
+variable 6 4 2 .h1Xh1Y.scalerRate HMS S1T
 variable 6 9 1 .CSUM.scaler HMS CSUM
 variable 6 9 2 .CSUM.scalerRate HMS CSUM
 variable 0 13 1 .hod.1x12.posScaler HMS 1X+ paddle 12
 variable 0 13 2 .hod.1x12.posScalerRate HMS 1X+ paddle 12
 variable 0 29 1 .hod.1x12.negScaler HMS 1X- paddle 12
 variable 0 29 2 .hod.1x12.negScalerRate HMS 1X- paddle 12
+variable 6 7 1 .ASUM.scaler HMS ASUM
+variable 6 7 2 .ASUM.scalerRate HMS ASUM
 variable 2 0 1 .hod.2x1.posScaler HMS 2X+ paddle 1
 variable 2 0 2 .hod.2x1.posScalerRate HMS 2X+ paddle 1
 variable 2 16 1 .hod.2x1.negScaler HMS 2X- paddle 1
@@ -97,14 +103,12 @@ variable 2 31 1 .hod.2x16.negScaler HMS 2X- paddle 16
 variable 2 31 2 .hod.2x16.negScalerRate HMS 2X- paddle 16
 variable 0 6 1 .hod.1x6.posScaler HMS 1X+ paddle 6
 variable 0 6 2 .hod.1x6.posScalerRate HMS 1X+ paddle 6
-variable 6 0 1 .S1X.scaler HMS S1X
-variable 6 0 2 .S1X.scalerRate HMS S1X
-variable 6 1 1 .S1Y.scaler HMS S1Y
-variable 6 1 2 .S1Y.scalerRate HMS S1Y
 variable 0 30 1 .hod.1x14.negScaler HMS 1X- paddle 14
 variable 0 30 2 .hod.1x14.negScalerRate HMS 1X- paddle 14
-variable 6 7 1 .ASUM.scaler HMS ASUM
-variable 6 7 2 .ASUM.scalerRate HMS ASUM
+variable 6 2 1 .h2X.scaler HMS S2X
+variable 6 2 2 .h2X.scalerRate HMS S2X
+variable 6 3 1 .h2Y.scaler HMS S2Y
+variable 6 3 2 .h2Y.scalerRate HMS S2Y
 variable 6 27 1 .BCM1.scaler bcm1
 variable 6 27 2 .BCM1.scalerRate bcm1
 variable 0 14 1 .hod.1x14.posScaler HMS 1X+ paddle 14
@@ -141,10 +145,12 @@ variable 0 19 1 .hod.1x7.negScaler HMS 1X- paddle 7
 variable 0 19 2 .hod.1x7.negScalerRate HMS 1X- paddle 7
 variable 0 3 1 .hod.1x7.posScaler HMS 1X+ paddle 7
 variable 0 3 2 .hod.1x7.posScalerRate HMS 1X+ paddle 7
-variable 6 14 1 .AERSUM.scaler HMS AERSUM
-variable 6 14 2 .AERSUM.scalerRate HMS AERSUM
 variable 2 12 1 .hod.2x10.posScaler HMS 2X+ paddle 10
 variable 2 12 2 .hod.2x10.posScalerRate HMS 2X+ paddle 10
+variable 6 1 1 .h1Y.scaler HMS S1Y
+variable 6 1 2 .h1Y.scalerRate HMS S1Y
+variable 6 0 1 .h1X.scaler HMS S1X
+variable 6 0 2 .h1X.scalerRate HMS S1X
 variable 6 25 1 .BCM4A.scaler bcm4a
 variable 6 25 2 .BCM4A.scalerRate bcm4a
 variable 0 31 1 .hod.1x16.negScaler HMS 1X- paddle 16
@@ -195,8 +201,6 @@ variable 2 2 1 .hod.2x5.posScaler HMS 2X+ paddle 5
 variable 2 2 2 .hod.2x5.posScalerRate HMS 2X+ paddle 5
 variable 2 29 1 .hod.2x12.negScaler HMS 2X- paddle 12
 variable 2 29 2 .hod.2x12.negScalerRate HMS 2X- paddle 12
-variable 6 8 1 .BSUM.scaler HMS BSUM
-variable 6 8 2 .BSUM.scalerRate HMS BSUM
 variable 2 13 1 .hod.2x12.posScaler HMS 2X+ paddle 12
 variable 2 13 2 .hod.2x12.posScalerRate HMS 2X+ paddle 12
 variable 0 4 1 .hod.1x2.posScaler HMS 1X+ paddle 2
@@ -241,8 +245,8 @@ variable 2 21 1 .hod.2x4.negScaler HMS 2X- paddle 4
 variable 2 21 2 .hod.2x4.negScalerRate HMS 2X- paddle 4
 variable 2 5 1 .hod.2x4.posScaler HMS 2X+ paddle 4
 variable 2 5 2 .hod.2x4.posScalerRate HMS 2X+ paddle 4
-variable 6 4 1 .S1XS1Y.scaler HMS S1T
-variable 6 4 2 .S1XS1Y.scalerRate HMS S1T
+variable 6 8 1 .BSUM.scaler HMS BSUM
+variable 6 8 2 .BSUM.scalerRate HMS BSUM
 variable 6 15 1 .CERSUM.scaler HMS CERSUM
 variable 6 15 2 .CERSUM.scalerRate HMS CERSUM
 variable 6 13 1 .SHWR.scaler HMS SHWR
@@ -269,8 +273,6 @@ variable 0 12 1 .hod.1x10.posScaler HMS 1X+ paddle 10
 variable 0 12 2 .hod.1x10.posScalerRate HMS 1X+ paddle 10
 variable 0 28 1 .hod.1x10.negScaler HMS 1X- paddle 10
 variable 0 28 2 .hod.1x10.negScalerRate HMS 1X- paddle 10
-variable 6 5 1 .S2XS2Y.scaler HMS S2T
-variable 6 5 2 .S2XS2Y.scalerRate HMS S2T
 variable 3 0 1 .hod.2y1.posScaler HMS 2Y+ paddle 1
 variable 3 0 2 .hod.2y1.posScalerRate HMS 2Y+ paddle 1
 variable 3 28 1 .hod.2y10.negScaler HMS 2Y- paddle 10
@@ -295,14 +297,12 @@ variable 2 30 1 .hod.2x14.negScaler HMS 2X- paddle 14
 variable 2 30 2 .hod.2x14.negScalerRate HMS 2X- paddle 14
 variable 2 14 1 .hod.2x14.posScaler HMS 2X+ paddle 14
 variable 2 14 2 .hod.2x14.posScalerRate HMS 2X+ paddle 14
-variable 6 3 1 .S2Y.scaler HMS S2Y
-variable 6 3 2 .S2Y.scalerRate HMS S2Y
-variable 6 2 1 .S2X.scaler HMS S2X
-variable 6 2 2 .S2X.scalerRate HMS S2X
 variable 1 1 1 .hod.1y3.posScaler HMS 1Y+ paddle 3
 variable 1 1 2 .hod.1y3.posScalerRate HMS 1Y+ paddle 3
 variable 1 17 1 .hod.1y3.negScaler HMS 1Y- paddle 3
 variable 1 17 2 .hod.1y3.negScalerRate HMS 1Y- paddle 3
+variable 6 14 1 .HOD_EDTM.scaler HMS HODO EDTM
+variable 6 14 2 .HOD_EDTM.scalerRate HMS HODO EDTM
 variable 0 26 1 .hod.1x13.negScaler HMS 1X- paddle 13
 variable 0 26 2 .hod.1x13.negScalerRate HMS 1X- paddle 13
 variable 0 10 1 .hod.1x13.posScaler HMS 1X+ paddle 13

--- a/MAPS/SCALERS/db_PScalevt.dat
+++ b/MAPS/SCALERS/db_PScalevt.dat
@@ -18,8 +18,6 @@ variable 3 15 1 .hod.2y16.posScaler SHMS 2y+ paddle 16
 variable 3 15 2 .hod.2y16.posScalerRate SHMS 2y+ paddle 16
 variable 3 31 1 .hod.2y16.negScaler SHMS 2y- paddle 16
 variable 3 31 2 .hod.2y16.negScalerRate SHMS 2y- paddle 16
-variable 2 19 1 .hod.2x7.negScaler SHMS 2X- paddle 7
-variable 2 19 2 .hod.2x7.negScalerRate SHMS 2X- paddle 7
 variable 3 27 1 .hod.2y15.negScaler SHMS 2y- paddle 15
 variable 3 27 2 .hod.2y15.negScalerRate SHMS 2y- paddle 15
 variable 3 23 1 .hod.2y8.negScaler SHMS 2y- paddle 8
@@ -38,8 +36,6 @@ variable 7 28 1 .BCM2.scaler bcm2
 variable 7 28 2 .BCM2.scalerRate bcm2
 variable 1 20 1 .hod.1y2.posScaler SHMS 1Y+ paddle 2
 variable 1 20 2 .hod.1y2.posScalerRate SHMS 1Y+ paddle 2
-variable 0 5 1 .hod.1x4.posScaler SHMS 1X+ paddle 4
-variable 0 5 2 .hod.1x4.posScalerRate SHMS 1X+ paddle 4
 variable 0 23 1 .hod.1x8.negScaler SHMS 1X- paddle 8
 variable 0 23 2 .hod.1x8.negScalerRate SHMS 1X- paddle 8
 variable 0 7 1 .hod.1x8.posScaler SHMS 1X+ paddle 8
@@ -88,8 +84,6 @@ variable 2 14 1 .hod.2x14.posScaler SHMS 2X+ paddle 14
 variable 2 14 2 .hod.2x14.posScalerRate SHMS 2X+ paddle 14
 variable 3 28 1 .hod.2y10.negScaler SHMS 2y- paddle 10
 variable 3 28 2 .hod.2y10.negScalerRate SHMS 2y- paddle 10
-variable 7 10 1 .DSUM.scaler SHMS DSUM
-variable 7 10 2 .DSUM.scalerRate SHMS DSUM
 variable 3 12 1 .hod.2y10.posScaler SHMS 2y+ paddle 10
 variable 3 12 2 .hod.2y10.posScalerRate SHMS 2y+ paddle 10
 variable 3 17 1 .hod.2y3.negScaler SHMS 2y- paddle 3
@@ -150,8 +144,6 @@ variable 3 4 1 .hod.2y2.posScaler SHMS 2y+ paddle 2
 variable 3 4 2 .hod.2y2.posScalerRate SHMS 2y+ paddle 2
 variable 2 16 1 .hod.2x1.negScaler SHMS 2X- paddle 1
 variable 2 16 2 .hod.2x1.negScalerRate SHMS 2X- paddle 1
-variable 7 14 1 .AERSUM.scaler SHMS AERSUM
-variable 7 14 2 .AERSUM.scalerRate SHMS AERSUM
 variable 0 26 1 .hod.1x13.negScaler SHMS 1X- paddle 13
 variable 0 26 2 .hod.1x13.negScalerRate SHMS 1X- paddle 13
 variable 0 10 1 .hod.1x13.posScaler SHMS 1X+ paddle 13
@@ -162,6 +154,8 @@ variable 0 13 1 .hod.1x12.posScaler SHMS 1X+ paddle 12
 variable 0 13 2 .hod.1x12.posScalerRate SHMS 1X+ paddle 12
 variable 3 24 1 .hod.2y9.negScaler SHMS 2y- paddle 9
 variable 3 24 2 .hod.2y9.negScalerRate SHMS 2y- paddle 9
+variable 7 10 1 .HOD_EDTM.scaler SHMS HODO EDTM
+variable 7 10 2 .HOD_EDTM.scalerRate SHMS HODO EDTM
 variable 1 21 1 .hod.1y4.posScaler SHMS 1Y+ paddle 4
 variable 1 21 2 .hod.1y4.posScalerRate SHMS 1Y+ paddle 4
 variable 2 8 1 .hod.2x9.posScaler SHMS 2X+ paddle 9
@@ -240,6 +234,8 @@ variable 1 6 1 .hod.1y6.negScaler SHMS 1Y- paddle 6
 variable 1 6 2 .hod.1y6.negScalerRate SHMS 1Y- paddle 6
 variable 3 0 1 .hod.2y1.posScaler SHMS 2y+ paddle 1
 variable 3 0 2 .hod.2y1.posScalerRate SHMS 2y+ paddle 1
+variable 0 5 1 .hod.1x4.posScaler SHMS 1X+ paddle 4
+variable 0 5 2 .hod.1x4.posScalerRate SHMS 1X+ paddle 4
 variable 0 21 1 .hod.1x4.negScaler SHMS 1X- paddle 4
 variable 0 21 2 .hod.1x4.negScalerRate SHMS 1X- paddle 4
 variable 2 3 1 .hod.2x7.posScaler SHMS 2X+ paddle 7
@@ -260,6 +256,8 @@ variable 7 26 1 .BCM4B.scaler bcm4b
 variable 7 26 2 .BCM4B.scalerRate bcm4b
 variable 2 23 1 .hod.2x8.negScaler SHMS 2X- paddle 8
 variable 2 23 2 .hod.2x8.negScalerRate SHMS 2X- paddle 8
+variable 2 19 1 .hod.2x7.negScaler SHMS 2X- paddle 7
+variable 2 19 2 .hod.2x7.negScalerRate SHMS 2X- paddle 7
 variable 7 9 1 .CSUM.scaler SHMS CSUM
 variable 7 9 2 .CSUM.scalerRate SHMS CSUM
 variable 3 19 1 .hod.2y7.negScaler SHMS 2y- paddle 7
@@ -270,6 +268,8 @@ variable 1 0 1 .hod.1y1.negScaler SHMS 1Y- paddle 1
 variable 1 0 2 .hod.1y1.negScalerRate SHMS 1Y- paddle 1
 variable 2 1 1 .hod.2x3.posScaler SHMS 2X+ paddle 3
 variable 2 1 2 .hod.2x3.posScalerRate SHMS 2X+ paddle 3
+variable 7 14 1 .AERSUM.scaler SHMS AERSUM
+variable 7 14 2 .AERSUM.scalerRate SHMS AERSUM
 variable 1 16 1 .hod.1y1.posScaler SHMS 1Y+ paddle 1
 variable 1 16 2 .hod.1y1.posScalerRate SHMS 1Y+ paddle 1
 variable 0 18 1 .hod.1x5.negScaler SHMS 1X- paddle 5

--- a/MAPS/SCALERS/scaler.map
+++ b/MAPS/SCALERS/scaler.map
@@ -191,12 +191,12 @@ Empty        0    4     3    30    1     Empty
 Empty        0    4     3    31    1     Empty
 
 # desc      hel crate slot start nchan  long-description                            
-S1X          0    4     6    0     1     HMS S1X                                           
-S1Y          0    4     6    1     1     HMS S1Y                                           
-S2X          0    4     6    2     1     HMS S2X                                           
-S2Y          0    4     6    3     1     HMS S2Y                                           
-S1XS1Y       0    4     6    4     1     HMS S1T                                           
-S2XS2Y       0    4     6    5     1     HMS S2T                                           
+h1X          0    4     6    0     1     HMS S1X                                           
+h1Y          0    4     6    1     1     HMS S1Y                                           
+h2X          0    4     6    2     1     HMS S2X                                           
+h2Y          0    4     6    3     1     HMS S2Y                                           
+h1Xh1Y       0    4     6    4     1     HMS S1T                                           
+h2Xh2Y       0    4     6    5     1     HMS S2T                                           
 Trig         0    4     6    6     1     HMS T1                                           
 ASUM         0    4     6    7     1     HMS ASUM                                         
 BSUM         0    4     6    8     1     HMS BSUM                                         
@@ -205,7 +205,7 @@ DSUM         0    4     6    10    1     HMS DSUM
 PSHWRLO      0    4     6    11    1     HMS PSHWRLO                                      
 PSHWRHI      0    4     6    12    1     HMS PSHWRHI                                      
 SHWR         0    4     6    13    1     HMS SHWR                                         
-AERSUM       0    4     6    14    1     HMS AERSUM                                       
+HOD_EDTM     0    4     6    14    1     HMS HODO EDTM                                       
 CERSUM       0    4     6    15    1     HMS CERSUM                                       
 BCM4A        0    4     6    25    1     bcm4a                                           
 BCM4B        0    4     6    26    1     bcm4b                                           
@@ -361,7 +361,7 @@ Trig         0    5     7    6     1     SHMS T1
 ASUM         0    5     7    7     1     SHMS ASUM                                         
 BSUM         0    5     7    8     1     SHMS BSUM                                         
 CSUM         0    5     7    9     1     SHMS CSUM                                         
-DSUM         0    5     7    10    1     SHMS DSUM                                         
+HOD_EDTM     0    5     7    10    1     SHMS HODO EDTM                                          
 PSHWRLO      0    5     7    11    1     SHMS PSHWRLO                                      
 PSHWRHI      0    5     7    12    1     SHMS PSHWRHI                                      
 SHWR         0    5     7    13    1     SHMS SHWR                                         

--- a/MAPS/SHMS/DETEC/AERO/paero_ptrig.map
+++ b/MAPS/SHMS/DETEC/AERO/paero_ptrig.map
@@ -26,6 +26,7 @@ SLOT=19
   39,   2,  10,   1  ! pAERSUM
   40,   2,  11,   1  ! pHGCSUM
   41,   2,  12,   1  ! pNGCSUM
+  42,   2,  23,   1  ! pHODO_EDTM
 
 ROC=6
 

--- a/MAPS/SHMS/DETEC/HGCER/phgcer_ptrig.map
+++ b/MAPS/SHMS/DETEC/HGCER/phgcer_ptrig.map
@@ -26,6 +26,7 @@ SLOT=19
   39,   2,  10,   1  ! pAERSUM
   40,   2,  11,   1  ! pHGCERSUM
   41,   2,  12,   1  ! pNGCERSUM
+  42,   2,  23,   1  ! pHODO_EDTM
 
 ROC=6
 

--- a/MAPS/SHMS/DETEC/HODO/phodo_ptrig.map
+++ b/MAPS/SHMS/DETEC/HODO/phodo_ptrig.map
@@ -26,6 +26,7 @@ SLOT=19
   39,   2,  10,   1  ! pAERSUM
   40,   2,  11,   1  ! pHGCERSUM
   41,   2,  12,   1  ! pNGCERSUM
+  42,   2,  23,   1  ! pHODO_EDTM
 
 ROC=6
 

--- a/MAPS/SHMS/DETEC/NGCER/pngcer_ptrig.map
+++ b/MAPS/SHMS/DETEC/NGCER/pngcer_ptrig.map
@@ -26,6 +26,7 @@ SLOT=19
   39,   2,  10,   1  ! pAERSUM
   40,   2,  11,   1  ! pHGCERSUM
   41,   2,  12,   1  ! pNGCERSUM
+  42,   2,  23,   1  ! pHODO_EDTM
 
 ROC=6
 

--- a/MAPS/SHMS/DETEC/STACK/shms_stack.map
+++ b/MAPS/SHMS/DETEC/STACK/shms_stack.map
@@ -36,6 +36,7 @@ REFINDEX=0
   39,   2,  10,   1  ! pAERSUM
   40,   2,  11,   1  ! pHGCERSUM
   41,   2,  12,   1  ! pNGCERSUM
+  42,   2,  23,   1  ! pHODO_EDTM
 
 ROC=6
 

--- a/MAPS/SHMS/DETEC/TRIG/ptrig.map
+++ b/MAPS/SHMS/DETEC/TRIG/ptrig.map
@@ -31,6 +31,7 @@ REFINDEX=0
   39,   2,  10,   1  ! pAERSUM
   40,   2,  11,   1  ! pHGCERSUM
   41,   2,  12,   1  ! pNGCERSUM
+  42,   2,  23,   1  ! pHODO_EDTM
 
 ROC=6
 

--- a/PARAM/TRIG/thms.param
+++ b/PARAM/TRIG/thms.param
@@ -6,5 +6,5 @@ t_hms_tdcchanperns=0.1
 ; bar num:        1     2     3     4     5      6     7       8       9     10    11    12
 t_hms_adcNames = "hASUM hBSUM hCSUM hDSUM hPSHWR hSHWR hAERSUM hCERSUM hFRXA hFRYA hFRXB hFRYB"
 
-; bar num:              1   2   3   4   5   6   7   8     9     10    11    12       13       14    15      16      17    18      19     20      21
-t_hms_tdcNames = "h1X h1Y h2X h2Y h1T h2T hT1 hASUM hBSUM hCSUM hDSUM hPSHWRLO hPSHWRHI hSHWR hAERSUM hCERSUM hT2 hDCREF1 hDCREF2 hDCREF3 hDCREF4"
+; bar num:        1   2   3   4   5   6   7   8     9     10    11    12       13       14    15         16      17  18      19      20      21
+t_hms_tdcNames = "h1X h1Y h2X h2Y h1T h2T hT1 hASUM hBSUM hCSUM hDSUM hPSHWRLO hPSHWRHI hSHWR hHODO_EDTM hCERSUM hT2 hDCREF1 hDCREF2 hDCREF3 hDCREF4"

--- a/PARAM/TRIG/tshms.param
+++ b/PARAM/TRIG/tshms.param
@@ -1,10 +1,10 @@
 t_shms_numAdc = 7
-t_shms_numTdc = 22
+t_shms_numTdc = 23
 t_shms_tdcoffset = -300.
 t_shms_tdcchanperns = 0.1
 
 ; bar num:            1       2       3      4     5     6     7
 t_shms_adcNames = "pAERSUM pHGCSUM pNGCSUM pFRXA pFRYA pFRXB pFRYB"
 
-; bar num:          1   2   3   4   5   6   7   8   9     10      11      12      13     14      15      16      17      18      19      20      21       22
-t_shms_tdcNames = "pT1 pT2 p1X p1Y p2X p2Y p1T p2T pT3 pAERSUM pHGCSUM pNGCSUM pDCREF1 pDCREF2 pDCREF3 pDCREF4 pDCREF5 pDCREF6 pDCREF7 pDCREF8 pDCREF9 pDCREF10"
+; bar num:          1   2   3   4   5   6   7   8   9     10      11      12      13     14      15      16      17      18      19      20      21       22     23
+t_shms_tdcNames = "pT1 pT2 p1X p1Y p2X p2Y p1T p2T pT3 pAERSUM pHGCSUM pNGCSUM pDCREF1 pDCREF2 pDCREF3 pDCREF4 pDCREF5 pDCREF6 pDCREF7 pDCREF8 pDCREF9 pDCREF10 pHODO_EDTM"


### PR DESCRIPTION
…ms.* in epics_short.def in order to produce HMS Hodo EDTM leaf variable; Added Hodo EDTM to scaler.map
NOTE: HMS AERO TRG had to be replaced with Hodo EDTM in maps as we had all channels occupied in
a CAMAC module, and since the HMS Aero will not be used in the near future (Commissioning), it was decided that it is safe to replace it by HMS Hodo EDTM.