### PR TITLE
Add gscalers.param to PARAM

### DIFF
--- a/DBASE/SHMS/GEN/general.param
+++ b/DBASE/SHMS/GEN/general.param
@@ -8,6 +8,7 @@ cminch=2.54
 #include "PARAM/GEN/gdebug.param"
 #include "PARAM/GEN/gtarget.param"
 #include "PARAM/GEN/gbeam.param"
+#include "PARAM/GEN/gscalers.param"
 
 ; General SHMS parameter files
 ; Note: shmsflags.param includes spectrometer offsets and options.

--- a/PARAM/GEN/gscalers.param
+++ b/PARAM/GEN/gscalers.param
@@ -1,0 +1,10 @@
+gbcm1_gain = 0.000328739              ; microA/Hz (New Value)
+gbcm2_gain = 0.000381677              ; microA/Hz (New Value)
+gbcm3_gain = 0.00043343               ; microA/Hz (Old, Value)
+
+gbcm1_offset =  250842.               ; Hz (New Value)
+gbcm2_offset =  250567.               ; Hz (New Value)
+gbcm3_offset =  245437.               ; Hz (Old, Value)
+
+gunser_offset =  514529.              ; Hz (Old, Value)
+gunser_gain = 0.00025001              ; microA/Hz (New Value)


### PR DESCRIPTION
gscalers.param will have the parameters for converting the BCM scalers into charge and current.