### PR TITLE
Find coda files in a path list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
+*.sw?
 ROOTfiles
 ROOTfiles/*
 ROOTfiles.old/*

--- a/SCRIPTS/COIN/PRODUCTION/replay_production_coin.C
+++ b/SCRIPTS/COIN/PRODUCTION/replay_production_coin.C
@@ -16,7 +16,12 @@ void replay_production_coin (Int_t RunNumber = 0, Int_t MaxEvent = 0) {
   }
 
   // Create file name patterns.
-  const char* RunFileNamePattern = "raw/shms_all_%05d.dat";
+  const char* RunFileNamePattern = "shms_all_%05d.dat";
+  vector<TString> pathList;
+    pathList.push_back(".");
+    pathList.push_back("./raw");
+    pathList.push_back("./cache");
+
   //const char* RunFileNamePattern = "raw/coin_all_%05d.dat";
   const char* ROOTFileNamePattern = "ROOTfiles/coin_replay_production_%d_%d.root";
   
@@ -151,9 +156,7 @@ void replay_production_coin (Int_t RunNumber = 0, Int_t MaxEvent = 0) {
 
   // Define the run(s) that we want to analyze.
   // We just set up one, but this could be many.
-  char RunFileName[100];
-  sprintf(RunFileName, RunFileNamePattern, RunNumber);
-  THaRun* run = new THaRun(RunFileName);
+  THaRun* run = new THaRun( pathList, Form(RunFileNamePattern, RunNumber) );
 
   // Set to read in Hall C run database parameters
   run->SetRunParamClass("THcRunParameters");

--- a/SCRIPTS/HMS/PRODUCTION/replay_production_hms.C
+++ b/SCRIPTS/HMS/PRODUCTION/replay_production_hms.C
@@ -16,7 +16,12 @@ void replay_production_hms(Int_t RunNumber=0, Int_t MaxEvent=0) {
   }
 
   // Create file name patterns.
-  const char* RunFileNamePattern = "raw/hms_all_%05d.dat";
+  const char* RunFileNamePattern = "hms_all_%05d.dat";
+  vector<TString> pathList;
+    pathList.push_back(".");
+    pathList.push_back("./raw");
+    pathList.push_back("./cache");
+
   const char* ROOTFileNamePattern = "ROOTfiles/hms_replay_production_%d_%d.root";
 
   //Load Global parameters
@@ -98,9 +103,7 @@ void replay_production_hms(Int_t RunNumber=0, Int_t MaxEvent=0) {
 
   // Define the run(s) that we want to analyze.
   // We just set up one, but this could be many.
-  char RunFileName[100];
-  sprintf(RunFileName, RunFileNamePattern, RunNumber);
-  THaRun* run = new THaRun(RunFileName);
+  THaRun* run = new THaRun( pathList, Form(RunFileNamePattern, RunNumber) );
 
   // Set to read in Hall C run database parameters
   run->SetRunParamClass("THcRunParameters");

--- a/SCRIPTS/HMS/RASTER/replay_hms_raster_simple.C
+++ b/SCRIPTS/HMS/RASTER/replay_hms_raster_simple.C
@@ -16,7 +16,12 @@ void replay_hms_raster_simple(Int_t RunNumber=0, Int_t MaxEvent=0) {
   }
 
   // Create file name patterns.
-  const char* RunFileNamePattern = "raw/hms_all_%05d.dat";
+  const char* RunFileNamePattern = "hms_all_%05d.dat";
+  vector<TString> pathList;
+    pathList.push_back(".");
+    pathList.push_back("./raw");
+    pathList.push_back("./cache");
+
   const char* ROOTFileNamePattern = "ROOTfiles/hms_raster_simple_%d_%d.root";
   // Add variables to global list.
   gHcParms->Define("gen_run_number", "Run Number", RunNumber);
@@ -57,9 +62,7 @@ void replay_hms_raster_simple(Int_t RunNumber=0, Int_t MaxEvent=0) {
 
   // Define the run(s) that we want to analyze.
   // We just set up one, but this could be many.
-  char RunFileName[100];
-  sprintf(RunFileName, RunFileNamePattern, RunNumber);
-  THaRun* run = new THaRun(RunFileName);
+  THaRun* run = new THaRun( pathList, Form(RunFileNamePattern, RunNumber) );
 
   // Eventually need to learn to skip over, or properly analyze
   // the pedestal events

--- a/SCRIPTS/HMS/SCALERS/replay_hms_scalers.C
+++ b/SCRIPTS/HMS/SCALERS/replay_hms_scalers.C
@@ -16,7 +16,12 @@ void replay_hms_scalers(Int_t RunNumber=0, Int_t MaxEvent=0) {
   }
 
   // Create file name patterns.
-  const char* RunFileNamePattern = "raw/hms_all_%05d.dat";
+  const char* RunFileNamePattern = "hms_all_%05d.dat";
+  vector<TString> pathList;
+    pathList.push_back(".");
+    pathList.push_back("./raw");
+    pathList.push_back("./cache");
+
   const char* ROOTFileNamePattern = "ROOTfiles/hms_replay_scalers_%d_%d.root";
   
   // Load global parameters
@@ -66,9 +71,7 @@ void replay_hms_scalers(Int_t RunNumber=0, Int_t MaxEvent=0) {
 
   // Define the run(s) that we want to analyze.
   // We just set up one, but this could be many.
-  char RunFileName[100];
-  sprintf(RunFileName, RunFileNamePattern, RunNumber);
-  THaRun* run = new THaRun(RunFileName);
+  THaRun* run = new THaRun( pathList, Form(RunFileNamePattern, RunNumber) );
 
   // Eventually need to learn to skip over, or properly analyze
   // the pedestal events

--- a/SCRIPTS/HMS/STACK/replay_hms.C
+++ b/SCRIPTS/HMS/STACK/replay_hms.C
@@ -16,7 +16,12 @@ void replay_hms(Int_t RunNumber=0, Int_t MaxEvent=0) {
   }
 
   // Create file name patterns.
-  const char* RunFileNamePattern = "raw/hms_all_%05d.dat";
+  const char* RunFileNamePattern = "hms_all_%05d.dat";
+  vector<TString> pathList;
+    pathList.push_back(".");
+    pathList.push_back("./raw");
+    pathList.push_back("./cache");
+
   const char* ROOTFileNamePattern = "ROOTfiles/hms_replay_%d_%d.root";
   // Add variables to global list.
   gHcParms->Define("gen_run_number", "Run Number", RunNumber);
@@ -80,9 +85,7 @@ void replay_hms(Int_t RunNumber=0, Int_t MaxEvent=0) {
 
   // Define the run(s) that we want to analyze.
   // We just set up one, but this could be many.
-  char RunFileName[100];
-  sprintf(RunFileName, RunFileNamePattern, RunNumber);
-  THaRun* run = new THaRun(RunFileName);
+  THaRun* run = new THaRun( pathList, Form(RunFileNamePattern, RunNumber) );
 
   // Eventually need to learn to skip over, or properly analyze
   // the pedestal events

--- a/SCRIPTS/HMS/TEST_STANDS/replay_hcal_test_stand.C
+++ b/SCRIPTS/HMS/TEST_STANDS/replay_hcal_test_stand.C
@@ -16,7 +16,12 @@ void replay_hcal_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
   }
 
   // Create file name patterns.
-  const char* RunFileNamePattern = "raw/hms_all_%05d.dat";
+  const char* RunFileNamePattern = "hms_all_%05d.dat";
+  vector<TString> pathList;
+    pathList.push_back(".");
+    pathList.push_back("./raw");
+    pathList.push_back("./cache");
+
   const char* ROOTFileNamePattern = "ROOTfiles/hcal_replay_%d.root";
   // Add variables to global list.
   gHcParms->Define("gen_run_number", "Run Number", RunNumber);
@@ -58,9 +63,7 @@ void replay_hcal_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
 
   // Define the run(s) that we want to analyze.
   // We just set up one, but this could be many.
-  char RunFileName[100];
-  sprintf(RunFileName, RunFileNamePattern, RunNumber);
-  THaRun* run = new THaRun(RunFileName);
+  THaRun* run = new THaRun( pathList, Form(RunFileNamePattern, RunNumber) );
 
   // Eventually need to learn to skip over, or properly analyze
   // the pedestal events

--- a/SCRIPTS/HMS/TEST_STANDS/replay_hcer_test_stand.C
+++ b/SCRIPTS/HMS/TEST_STANDS/replay_hcer_test_stand.C
@@ -16,7 +16,12 @@ void replay_hcer_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
   }
 
   // Create file name patterns.
-  const char* RunFileNamePattern = "raw/hms_all_%05d.dat";
+  const char* RunFileNamePattern = "hms_all_%05d.dat";
+  vector<TString> pathList;
+    pathList.push_back(".");
+    pathList.push_back("./raw");
+    pathList.push_back("./cache");
+
   const char* ROOTFileNamePattern = "ROOTfiles/hcer_replay_%d.root";
 
   // Add variables to global list.
@@ -68,9 +73,7 @@ void replay_hcer_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
 
   // Define the run(s) that we want to analyze.
   // We just set up one, but this could be many.
-  char RunFileName[100];
-  sprintf(RunFileName, RunFileNamePattern, RunNumber);
-  THaRun* run = new THaRun(RunFileName);
+  THaRun* run = new THaRun( pathList, Form(RunFileNamePattern, RunNumber) );
 
   // Eventually need to learn to skip over, or properly analyze
   // the pedestal events

--- a/SCRIPTS/HMS/TEST_STANDS/replay_hdc_test_stand.C
+++ b/SCRIPTS/HMS/TEST_STANDS/replay_hdc_test_stand.C
@@ -16,7 +16,12 @@ void replay_hdc_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
   }
 
   // Create file name patterns.
-  const char* RunFileNamePattern = "raw/hms_all_%05d.dat";
+  const char* RunFileNamePattern = "hms_all_%05d.dat";
+  vector<TString> pathList;
+    pathList.push_back(".");
+    pathList.push_back("./raw");
+    pathList.push_back("./cache");
+
   const char* ROOTFileNamePattern = "ROOTfiles/hdc_replay_%d.root";
 
   // Add variables to global list.
@@ -70,9 +75,7 @@ void replay_hdc_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
 
   // Define the run(s) that we want to analyze.
   // We just set up one, but this could be many.
-  char RunFileName[100];
-  sprintf(RunFileName, RunFileNamePattern, RunNumber);
-  THaRun* run = new THaRun(RunFileName);
+  THaRun* run = new THaRun( pathList, Form(RunFileNamePattern, RunNumber) );
 
   // Eventually need to learn to skip over, or properly analyze
   // the pedestal events

--- a/SCRIPTS/HMS/TEST_STANDS/replay_hhodo_test_stand.C
+++ b/SCRIPTS/HMS/TEST_STANDS/replay_hhodo_test_stand.C
@@ -16,7 +16,12 @@ void replay_hhodo_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
   }
 
   // Create file name patterns.
-  const char* RunFileNamePattern = "raw/hms_all_%05d.dat";
+  const char* RunFileNamePattern = "hms_all_%05d.dat";
+  vector<TString> pathList;
+    pathList.push_back(".");
+    pathList.push_back("./raw");
+    pathList.push_back("./cache");
+
   const char* ROOTFileNamePattern = "ROOTfiles/hhodo_replay_%d.root";
 
   // Add variables to global list.
@@ -68,9 +73,7 @@ void replay_hhodo_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
 
   // Define the run(s) that we want to analyze.
   // We just set up one, but this could be many.
-  char RunFileName[100];
-  sprintf(RunFileName, RunFileNamePattern, RunNumber);
-  THaRun* run = new THaRun(RunFileName);
+  THaRun* run = new THaRun( pathList, Form(RunFileNamePattern, RunNumber) );
 
   // Eventually need to learn to skip over, or properly analyze
   // the pedestal events

--- a/SCRIPTS/HMS/TEST_STANDS/replay_htrig_test_stand.C
+++ b/SCRIPTS/HMS/TEST_STANDS/replay_htrig_test_stand.C
@@ -16,7 +16,12 @@ void replay_htrig_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
   }
 
   // Create file name patterns.
-  const char* RunFileNamePattern = "raw/hms_all_%05d.dat";
+  const char* RunFileNamePattern = "hms_all_%05d.dat";
+  vector<TString> pathList;
+    pathList.push_back(".");
+    pathList.push_back("./raw");
+    pathList.push_back("./cache");
+
   const char* ROOTFileNamePattern = "ROOTfiles/htrig_replay_%d.root";
 
   // Add variables to global list.
@@ -60,9 +65,7 @@ void replay_htrig_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
 
   // Define the run(s) that we want to analyze.
   // We just set up one, but this could be many.
-  char RunFileName[100];
-  sprintf(RunFileName, RunFileNamePattern, RunNumber);
-  THaRun* run = new THaRun(RunFileName);
+  THaRun* run = new THaRun( pathList, Form(RunFileNamePattern, RunNumber) );
 
   // Eventually need to learn to skip over, or properly analyze
   // the pedestal events

--- a/SCRIPTS/SHMS/EXAMPLES/replay_workshop_example.C
+++ b/SCRIPTS/SHMS/EXAMPLES/replay_workshop_example.C
@@ -15,7 +15,12 @@ void replay_workshop_example(Int_t RunNumber=0, Int_t MaxEvent=0) {
     }
   }
   // Create file name patterns.
-  const char* RunFileNamePattern = "raw/shms_all_%05d.dat";
+  const char* RunFileNamePattern = "shms_all_%05d.dat";
+  vector<TString> pathList;
+    pathList.push_back(".");
+    pathList.push_back("./raw");
+    pathList.push_back("./cache");
+
   const char* ROOTFileNamePattern = "ROOTfiles/shms_replay_%d_%d.root";
   // Add variables to global list.
   gHcParms->Define("gen_run_number", "Run Number", RunNumber);
@@ -73,9 +78,7 @@ void replay_workshop_example(Int_t RunNumber=0, Int_t MaxEvent=0) {
 
   // Define the run(s) that we want to analyze.
   // We just set up one, but this could be many.
-  char RunFileName[100];
-  sprintf(RunFileName, RunFileNamePattern, RunNumber);
-  THaRun* run = new THaRun(RunFileName);
+  THaRun* run = new THaRun( pathList, Form(RunFileNamePattern, RunNumber) );
 
   // Eventually need to learn to skip over, or properly analyze
   // the pedestal events

--- a/SCRIPTS/SHMS/PRODUCTION/replay_production_shms.C
+++ b/SCRIPTS/SHMS/PRODUCTION/replay_production_shms.C
@@ -16,7 +16,12 @@ void replay_production_shms (Int_t RunNumber = 0, Int_t MaxEvent = 0) {
   }
 
   // Create file name patterns.
-  const char* RunFileNamePattern = "raw/shms_all_%05d.dat";
+  const char* RunFileNamePattern = "shms_all_%05d.dat";
+  vector<TString> pathList;
+    pathList.push_back(".");
+    pathList.push_back("./raw");
+    pathList.push_back("./cache");
+
   const char* ROOTFileNamePattern = "ROOTfiles/shms_replay_production_%d_%d.root";
   
   // Load global parameters
@@ -106,9 +111,7 @@ void replay_production_shms (Int_t RunNumber = 0, Int_t MaxEvent = 0) {
 
   // Define the run(s) that we want to analyze.
   // We just set up one, but this could be many.
-  char RunFileName[100];
-  sprintf(RunFileName, RunFileNamePattern, RunNumber);
-  THaRun* run = new THaRun(RunFileName);
+  THaRun* run = new THaRun( pathList, Form(RunFileNamePattern, RunNumber) );
 
   // Set to read in Hall C run database parameters
   run->SetRunParamClass("THcRunParameters");

--- a/SCRIPTS/SHMS/RASTER/replay_shms_raster_simple.C
+++ b/SCRIPTS/SHMS/RASTER/replay_shms_raster_simple.C
@@ -16,7 +16,12 @@ void replay_shms_raster_simple (Int_t RunNumber = 0, Int_t MaxEvent = 0) {
   }
 
   // Create file name patterns.
-  const char* RunFileNamePattern = "raw/shms_all_%05d.dat";
+  const char* RunFileNamePattern = "shms_all_%05d.dat";
+  vector<TString> pathList;
+    pathList.push_back(".");
+    pathList.push_back("./raw");
+    pathList.push_back("./cache");
+
   const char* ROOTFileNamePattern = "ROOTfiles/shms_replay_raster_simple_%d_%d.root";
   // Add variables to global list.
   gHcParms->Define("gen_run_number", "Run Number", RunNumber);
@@ -56,9 +61,7 @@ void replay_shms_raster_simple (Int_t RunNumber = 0, Int_t MaxEvent = 0) {
 
   // Define the run(s) that we want to analyze.
   // We just set up one, but this could be many.
-  char RunFileName[100];
-  sprintf(RunFileName, RunFileNamePattern, RunNumber);
-  THaRun* run = new THaRun(RunFileName);
+  THaRun* run = new THaRun( pathList, Form(RunFileNamePattern, RunNumber) );
 
   // Eventually need to learn to skip over, or properly analyze
   // the pedestal events

--- a/SCRIPTS/SHMS/SCALERS/replay_shms_scalers.C
+++ b/SCRIPTS/SHMS/SCALERS/replay_shms_scalers.C
@@ -16,7 +16,12 @@ void replay_shms_scalers (Int_t RunNumber = 0, Int_t MaxEvent = 0) {
   }
 
   // Create file name patterns.
-  const char* RunFileNamePattern = "raw/shms_all_%05d.dat";
+  const char* RunFileNamePattern = "shms_all_%05d.dat";
+  vector<TString> pathList;
+    pathList.push_back(".");
+    pathList.push_back("./raw");
+    pathList.push_back("./cache");
+
   const char* ROOTFileNamePattern = "ROOTfiles/shms_replay_scalers_%d_%d.root";
 
   // Load global parameters
@@ -66,9 +71,7 @@ void replay_shms_scalers (Int_t RunNumber = 0, Int_t MaxEvent = 0) {
 
   // Define the run(s) that we want to analyze.
   // We just set up one, but this could be many.
-  char RunFileName[100];
-  sprintf(RunFileName, RunFileNamePattern, RunNumber);
-  THaRun* run = new THaRun(RunFileName);
+  THaRun* run = new THaRun( pathList, Form(RunFileNamePattern, RunNumber) );
 
   // Eventually need to learn to skip over, or properly analyze
   // the pedestal events

--- a/SCRIPTS/SHMS/STACK/replay_shms.C
+++ b/SCRIPTS/SHMS/STACK/replay_shms.C
@@ -16,7 +16,12 @@ void replay_shms (Int_t RunNumber = 0, Int_t MaxEvent = 0) {
   }
 
   // Create file name patterns.
-  const char* RunFileNamePattern = "raw/shms_all_%05d.dat";
+  const char* RunFileNamePattern = "shms_all_%05d.dat";
+  vector<TString> pathList;
+    pathList.push_back(".");
+    pathList.push_back("./raw");
+    pathList.push_back("./cache");
+
   const char* ROOTFileNamePattern = "ROOTfiles/shms_replay_%d_%d.root";
   
   // Load global parameters
@@ -87,9 +92,7 @@ void replay_shms (Int_t RunNumber = 0, Int_t MaxEvent = 0) {
 
   // Define the run(s) that we want to analyze.
   // We just set up one, but this could be many.
-  char RunFileName[100];
-  sprintf(RunFileName, RunFileNamePattern, RunNumber);
-  THaRun* run = new THaRun(RunFileName);
+  THaRun* run = new THaRun( pathList, Form(RunFileNamePattern, RunNumber) );
 
   // Eventually need to learn to skip over, or properly analyze
   // the pedestal events

--- a/SCRIPTS/SHMS/TEST_STANDS/replay_paero_test_stand.C
+++ b/SCRIPTS/SHMS/TEST_STANDS/replay_paero_test_stand.C
@@ -16,7 +16,12 @@ void replay_paero_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
   }
 
   // Create file name patterns.
-  const char* RunFileNamePattern = "raw/shms_all_%05d.dat";
+  const char* RunFileNamePattern = "shms_all_%05d.dat";
+  vector<TString> pathList;
+    pathList.push_back(".");
+    pathList.push_back("./raw");
+    pathList.push_back("./cache");
+
   const char* ROOTFileNamePattern = "ROOTfiles/paero_replay_%d.root";
   // Add variables to global list.
   gHcParms->Define("gen_run_number", "Run Number", RunNumber);
@@ -69,9 +74,7 @@ void replay_paero_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
 
   // Define the run(s) that we want to analyze.
   // We just set up one, but this could be many.
-  char RunFileName[100];
-  sprintf(RunFileName, RunFileNamePattern, RunNumber);
-  THaRun* run = new THaRun(RunFileName);
+  THaRun* run = new THaRun( pathList, Form(RunFileNamePattern, RunNumber) );
 
   // Eventually need to learn to skip over, or properly analyze
   // the pedestal events

--- a/SCRIPTS/SHMS/TEST_STANDS/replay_pcal_test_stand.C
+++ b/SCRIPTS/SHMS/TEST_STANDS/replay_pcal_test_stand.C
@@ -16,7 +16,12 @@ void replay_pcal_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
   }
 
   // Create file name patterns
-  const char* RunFileNamePattern = "raw/shms_all_%05d.dat";
+  const char* RunFileNamePattern = "shms_all_%05d.dat";
+  vector<TString> pathList;
+    pathList.push_back(".");
+    pathList.push_back("./raw");
+    pathList.push_back("./cache");
+
   const char* ROOTFileNamePattern = "ROOTfiles/pcal_replay_%d.root";
   // Add variables to global list.
   gHcParms->Define("gen_run_number", "Run Number", RunNumber);
@@ -59,9 +64,7 @@ void replay_pcal_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
 
   // Define the run(s) that we want to analyze.
   // We just set up one, but this could be many.
-  char RunFileName[100];
-  sprintf(RunFileName, RunFileNamePattern, RunNumber);
-  THaRun* run = new THaRun(RunFileName);
+  THaRun* run = new THaRun( pathList, Form(RunFileNamePattern, RunNumber) );
 
   // Eventually need to learn to skip over, or properly analyze
   // the pedestal events

--- a/SCRIPTS/SHMS/TEST_STANDS/replay_pdc_test_stand.C
+++ b/SCRIPTS/SHMS/TEST_STANDS/replay_pdc_test_stand.C
@@ -16,7 +16,12 @@ void replay_pdc_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
   }
 
   // Create file name patterns.
-  const char* RunFileNamePattern = "raw/shms_all_%05d.dat";
+  const char* RunFileNamePattern = "shms_all_%05d.dat";
+  vector<TString> pathList;
+    pathList.push_back(".");
+    pathList.push_back("./raw");
+    pathList.push_back("./cache");
+
   const char* ROOTFileNamePattern = "ROOTfiles/pdc_replay_%d.root";
   // Add variables to global list.
   gHcParms->Define("gen_run_number", "Run Number", RunNumber);
@@ -63,9 +68,7 @@ void replay_pdc_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
 
   // Define the run(s) that we want to analyze.
   // We just set up one, but this could be many.
-  char RunFileName[100];
-  sprintf(RunFileName, RunFileNamePattern, RunNumber);
-  THaRun* run = new THaRun(RunFileName);
+  THaRun* run = new THaRun( pathList, Form(RunFileNamePattern, RunNumber) );
 
   // Eventually need to learn to skip over, or properly analyze
   // the pedestal events

--- a/SCRIPTS/SHMS/TEST_STANDS/replay_phgcer_test_stand.C
+++ b/SCRIPTS/SHMS/TEST_STANDS/replay_phgcer_test_stand.C
@@ -16,7 +16,12 @@ void replay_phgcer_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
   }
 
   // Create file name patterns.
-  const char* RunFileNamePattern = "raw/shms_all_%05d.dat";
+  const char* RunFileNamePattern = "shms_all_%05d.dat";
+  vector<TString> pathList;
+    pathList.push_back(".");
+    pathList.push_back("./raw");
+    pathList.push_back("./cache");
+
   const char* ROOTFileNamePattern = "ROOTfiles/phgcer_replay_%d.root";
   // Add variables to global list.
   gHcParms->Define("gen_run_number", "Run Number", RunNumber);
@@ -68,9 +73,7 @@ void replay_phgcer_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
 
   // Define the run(s) that we want to analyze.
   // We just set up one, but this could be many.
-  char RunFileName[100];
-  sprintf(RunFileName, RunFileNamePattern, RunNumber);
-  THaRun* run = new THaRun(RunFileName);
+  THaRun* run = new THaRun( pathList, Form(RunFileNamePattern, RunNumber) );
 
   // Eventually need to learn to skip over, or properly analyze
   // the pedestal events

--- a/SCRIPTS/SHMS/TEST_STANDS/replay_phodo_test_stand.C
+++ b/SCRIPTS/SHMS/TEST_STANDS/replay_phodo_test_stand.C
@@ -16,7 +16,12 @@ void replay_phodo_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
   }
 
   // Create file name patterns.
-  const char* RunFileNamePattern = "raw/shms_all_%05d.dat";
+  const char* RunFileNamePattern = "shms_all_%05d.dat";
+  vector<TString> pathList;
+    pathList.push_back(".");
+    pathList.push_back("./raw");
+    pathList.push_back("./cache");
+
   const char* ROOTFileNamePattern = "ROOTfiles/phodo_replay_%d.root";
   // Add variables to global list.
   gHcParms->Define("gen_run_number", "Run Number", RunNumber);
@@ -67,9 +72,7 @@ void replay_phodo_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
 
   // Define the run(s) that we want to analyze.
   // We just set up one, but this could be many.
-  char RunFileName[100];
-  sprintf(RunFileName, RunFileNamePattern, RunNumber);
-  THaRun* run = new THaRun(RunFileName);
+  THaRun* run = new THaRun( pathList, Form(RunFileNamePattern, RunNumber) );
 
   // Eventually need to learn to skip over, or properly analyze
   // the pedestal events

--- a/SCRIPTS/SHMS/TEST_STANDS/replay_pngcer_test_stand.C
+++ b/SCRIPTS/SHMS/TEST_STANDS/replay_pngcer_test_stand.C
@@ -16,7 +16,12 @@ void replay_pngcer_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
   }
 
   // Create file name patterns.
-  const char* RunFileNamePattern = "raw/shms_all_%05d.dat";
+  const char* RunFileNamePattern = "shms_all_%05d.dat";
+  vector<TString> pathList;
+    pathList.push_back(".");
+    pathList.push_back("./raw");
+    pathList.push_back("./cache");
+
   const char* ROOTFileNamePattern = "ROOTfiles/pngcer_replay_%d.root";
   // Add variables to global list.
   gHcParms->Define("gen_run_number", "Run Number", RunNumber);
@@ -68,9 +73,7 @@ void replay_pngcer_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
 
   // Define the run(s) that we want to analyze.
   // We just set up one, but this could be many.
-  char RunFileName[100];
-  sprintf(RunFileName, RunFileNamePattern, RunNumber);
-  THaRun* run = new THaRun(RunFileName);
+  THaRun* run = new THaRun( pathList, Form(RunFileNamePattern, RunNumber) );
 
   // Eventually need to learn to skip over, or properly analyze
   // the pedestal events

--- a/SCRIPTS/SHMS/TEST_STANDS/replay_ptrig_test_stand.C
+++ b/SCRIPTS/SHMS/TEST_STANDS/replay_ptrig_test_stand.C
@@ -16,7 +16,12 @@ void replay_ptrig_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
   }
 
   // Create file name patterns.
-  const char* RunFileNamePattern = "raw/shms_all_%05d.dat";
+  const char* RunFileNamePattern = "shms_all_%05d.dat";
+  vector<TString> pathList;
+    pathList.push_back(".");
+    pathList.push_back("./raw");
+    pathList.push_back("./cache");
+
   const char* ROOTFileNamePattern = "ROOTfiles/ptrig_replay_%d.root";
   // Add variables to global list.
   gHcParms->Define("gen_run_number", "Run Number", RunNumber);
@@ -61,9 +66,7 @@ void replay_ptrig_test_stand(Int_t RunNumber=0, Int_t MaxEvent=0) {
 
   // Define the run(s) that we want to analyze.
   // We just set up one, but this could be many.
-  char RunFileName[100];
-  sprintf(RunFileName, RunFileNamePattern, RunNumber);
-  THaRun* run = new THaRun(RunFileName);
+  THaRun* run = new THaRun( pathList, Form(RunFileNamePattern, RunNumber) );
 
   // Eventually need to learn to skip over, or properly analyze
   // the pedestal events

--- a/SCRIPTS/filter.pl
+++ b/SCRIPTS/filter.pl
@@ -1,0 +1,16 @@
+#!/usr/bin/perl
+
+use File::Slurp;
+
+
+my $file = read_file($ARGV[0]);
+
+$file =~ s/\Qchar RunFileName[100];\E\W*\Qsprintf(RunFileName, RunFileNamePattern, RunNumber);\E\W*\QTHaRun* run = new THaRun(RunFileName);\E/THaRun* run = new THaRun( pathList, Form(RunFileNamePattern, RunNumber) );/s;
+
+$file =~ s/\Qconst char* RunFileNamePattern = "\E.*?\/(.*?\.dat)";/const char* RunFileNamePattern = "$1";\n  vector<TString> pathList;\n    pathList.push_back(".");\n    pathList.push_back(".\/raw");\n    pathList.push_back(".\/cache");\n/s;
+
+#$file =~ s/\Qconst char* RunFileNamePattern = "raw\/\E(.*?%05d.dat)\Q";\E/
+
+
+write_file("$ARGV[0]", $file);
+


### PR DESCRIPTION
Update replay scripts to search in a list of paths.  This will be needed/
helpful when I turn on the flag in the data mover script to clean up
CODA files after they are verified to be on tape.  These updated scripts
are able to search across a list of paths, so they can look in ./raw first,
then check in ./cache -> /mss/cache/hallc/.../raw/ to find the data file.
Old scripts will still work.

- **NOTE**: The new functionality also requires the _podd submodule_ in hcana to
    be updated to include commit b8aa92c27759dffce163eb5d84261f303d66e260
    titled "Add THaRun constructor that can find a file in a path list".
    See https://github.com/JeffersonLab/analyzer/pull/140

- The default './raw' and './cache' pathnames that are searched here
  should generally be symlinks to the relevant local path on the Hall C
  cluster, and the /cache/mss/hallc/.../raw/ path, respectively.
