### PR TITLE
Add/update Pedestal_event definitions to HMS/misc def files

### DIFF
--- a/DEF-files/COIN/PRODUCTION/coin_production_cuts.def
+++ b/DEF-files/COIN/PRODUCTION/coin_production_cuts.def
@@ -1,6 +1,6 @@
 Block: RawDecode
 
-Pedestal_event     g.evtyp == 4
+Pedestal_event     g.evtyp == 99
 scalar_event       g.evtyp == 0
 HMS_event          g.evtyp == 1
 SHMS_event         g.evtyp == 1

--- a/DEF-files/HMS/SCALERS/hscaler_cuts.def
+++ b/DEF-files/HMS/SCALERS/hscaler_cuts.def
@@ -2,6 +2,7 @@
 
 Block: RawDecode
 
+Pedestal_event     g.evtyp == 99
 HMS_trig_1_event   g.evtyp == 1
 HMS_trig_2_event   g.evtyp == 2
 HMS_trig_3_event   g.evtyp == 3

--- a/DEF-files/HMS/TEST_STANDS/AERO/haeroana_cuts.def
+++ b/DEF-files/HMS/TEST_STANDS/AERO/haeroana_cuts.def
@@ -1,5 +1,6 @@
 Block: RawDecode
 
+Pedestal_event     g.evtyp == 99
 HMS_trig_1_event   g.evtyp == 1
 HMS_trig_2_event   g.evtyp == 2
 HMS_trig_3_event   g.evtyp == 3

--- a/DEF-files/HMS/TEST_STANDS/CAL/hcalana_cuts.def
+++ b/DEF-files/HMS/TEST_STANDS/CAL/hcalana_cuts.def
@@ -1,5 +1,6 @@
 Block: RawDecode
 
+Pedestal_event     g.evtyp == 99
 HMS_trig_1_event   g.evtyp == 1
 HMS_trig_2_event   g.evtyp == 2
 HMS_trig_3_event   g.evtyp == 3

--- a/DEF-files/HMS/TEST_STANDS/CER/hcerana_cuts.def
+++ b/DEF-files/HMS/TEST_STANDS/CER/hcerana_cuts.def
@@ -1,5 +1,6 @@
 Block: RawDecode
 
+Pedestal_event     g.evtyp == 99
 HMS_trig_1_event   g.evtyp == 1
 HMS_trig_2_event   g.evtyp == 2
 HMS_trig_3_event   g.evtyp == 3

--- a/DEF-files/HMS/TEST_STANDS/DC/hdcana_cuts.def
+++ b/DEF-files/HMS/TEST_STANDS/DC/hdcana_cuts.def
@@ -1,5 +1,6 @@
 Block: RawDecode
 
+Pedestal_event     g.evtyp == 99
 HMS_trig_1_event   g.evtyp == 1
 HMS_trig_2_event   g.evtyp == 2
 HMS_trig_3_event   g.evtyp == 3

--- a/DEF-files/HMS/TEST_STANDS/HODO/hhodoana_cuts.def
+++ b/DEF-files/HMS/TEST_STANDS/HODO/hhodoana_cuts.def
@@ -1,5 +1,6 @@
 Block: RawDecode
 
+Pedestal_event     g.evtyp == 99
 HMS_trig_1_event   g.evtyp == 1
 HMS_trig_2_event   g.evtyp == 2
 HMS_trig_3_event   g.evtyp == 3

--- a/DEF-files/HMS/TEST_STANDS/TRIG/htrigana_cuts.def
+++ b/DEF-files/HMS/TEST_STANDS/TRIG/htrigana_cuts.def
@@ -1,5 +1,6 @@
 Block: RawDecode
 
+Pedestal_event     g.evtyp == 99
 HMS_trig_1_event   g.evtyp == 1
 HMS_trig_2_event   g.evtyp == 2
 HMS_trig_3_event   g.evtyp == 3

--- a/DEF-files/SHMS/SCALERS/pscaler_cuts.def
+++ b/DEF-files/SHMS/SCALERS/pscaler_cuts.def
@@ -2,6 +2,7 @@
 
 Block: RawDecode
 
+Pedestal_event     g.evtyp == 99
 SHMS_trig_1_event   g.evtyp == 1
 SHMS_trig_2_event   g.evtyp == 2
 SHMS_trig_3_event   g.evtyp == 3


### PR DESCRIPTION
- The omission causes replay errors with the (unmodified) scripts
- This would seem to complete the changes started on the SHMS side in commit 1321191f5d8c8b961f6492e0fcd4426bb6c63923