### PR TITLE
Remove SetMinimum(0) from overlay2.C

### DIFF
--- a/onlineGUI/UTIL/GEN/overlay2.C
+++ b/onlineGUI/UTIL/GEN/overlay2.C
@@ -29,8 +29,6 @@ void overlay2(TString hist1name, TString hist2name, TString label1="", TString l
     H2->SetLineColor(2);
     H1->SetStats(0);
     H2->SetStats(0);
-    H1->SetMinimum(0);
-    H2->SetMinimum(0);
     H1->SetTitle(htitle);
     H2->SetTitle(htitle);
     H1->GetXaxis()->SetTitleSize(0.035);
@@ -41,7 +39,6 @@ void overlay2(TString hist1name, TString hist2name, TString label1="", TString l
     H1->GetYaxis()->SetLabelSize(0.03);
     H2->GetXaxis()->SetLabelSize(0.03);
     H2->GetYaxis()->SetLabelSize(0.03);
-
   }
  
   double xpos = H1->GetXaxis()->GetBinCenter(H1->GetXaxis()->GetFirst()+4);


### PR DESCRIPTION
H->SetMinimum(0) in overlay2 prevents the user from using SetLogY, so I removed it. The existing SetMinimum(1) line in online.C should already take care of appropriate y-axis scaling.