### PR TITLE
Add FADC debug to production replay scripts

### DIFF
--- a/SCRIPTS/HMS/PRODUCTION/replay_production_hms.C
+++ b/SCRIPTS/HMS/PRODUCTION/replay_production_hms.C
@@ -40,6 +40,7 @@ void replay_production_hms(Int_t RunNumber=0, Int_t MaxEvent=0) {
   // Load the Hall C detector map
   gHcDetectorMap = new THcDetectorMap();
   gHcDetectorMap->Load("MAPS/HMS/DETEC/STACK/hms_stack.map");
+  gHcParms->Load("PARAM/HMS/GEN/h_fadc_debug.param");
 
   // Add trigger apparatus
   THaApparatus* TRG = new THcTrigApp("T", "TRG");

--- a/SCRIPTS/SHMS/PRODUCTION/replay_production_shms.C
+++ b/SCRIPTS/SHMS/PRODUCTION/replay_production_shms.C
@@ -40,6 +40,7 @@ void replay_production_shms (Int_t RunNumber = 0, Int_t MaxEvent = 0) {
   // Load the Hall C detector map
   gHcDetectorMap = new THcDetectorMap();
   gHcDetectorMap->Load("MAPS/SHMS/DETEC/STACK/shms_stack.map");
+  gHcParms->Load("PARAM/SHMS/GEN/p_fadc_debug.param");
 
   // Add trigger apparatus
   THaApparatus* TRG = new THcTrigApp("T", "TRG");


### PR DESCRIPTION
Sets FADC debug flag to 1 in production replay scripts to make raw FADC variables available in the tree.