### PR TITLE
Expose actual prescale factors in report files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ bck/*
 *#*
 hcana
 raw
+cache
 .root_history
 HISTOGRAMS/*
 REPORT_OUTPUT

--- a/TEMPLATES/HMS/PRODUCTION/hstackana_production.template
+++ b/TEMPLATES/HMS/PRODUCTION/hstackana_production.template
@@ -43,12 +43,12 @@ Ps4_value = {ghconfig_ti_ps[3]}
 Ps5_value = {ghconfig_ti_ps[4]}
 Ps6_value = {ghconfig_ti_ps[5]}
 
-Ps1_factor = {floor(2**(ghconfig_ti_ps[0] - 1) + 1):%d}
-Ps2_factor = {floor(2**(ghconfig_ti_ps[1] - 1) + 1):%d}
-Ps3_factor = {floor(2**(ghconfig_ti_ps[2] - 1) + 1):%d}
-Ps4_factor = {floor(2**(ghconfig_ti_ps[3] - 1) + 1):%d}
-Ps5_factor = {floor(2**(ghconfig_ti_ps[4] - 1) + 1):%d}
-Ps6_factor = {floor(2**(ghconfig_ti_ps[5] - 1) + 1):%d}
+Ps1_factor = {ghconfig_ti_ps_factors[0]}
+Ps2_factor = {ghconfig_ti_ps_factors[1]}
+Ps3_factor = {ghconfig_ti_ps_factors[2]}
+Ps4_factor = {ghconfig_ti_ps_factors[3]}
+Ps5_factor = {ghconfig_ti_ps_factors[4]}
+Ps6_factor = {ghconfig_ti_ps_factors[5]}
 
 ***************
 * 3/4 Triggers

--- a/TEMPLATES/HMS/PRODUCTION/hstackana_production.template
+++ b/TEMPLATES/HMS/PRODUCTION/hstackana_production.template
@@ -36,13 +36,6 @@ Chamber 2: {hdc_zpos[6]:%6.2f} {hdc_zpos[7]:%6.2f} {hdc_zpos[8]:%6.2f}
 * DAQ Configuration
 ********************
 
-Ps1_value = {ghconfig_ti_ps[0]}
-Ps2_value = {ghconfig_ti_ps[1]}
-Ps3_value = {ghconfig_ti_ps[2]}
-Ps4_value = {ghconfig_ti_ps[3]}
-Ps5_value = {ghconfig_ti_ps[4]}
-Ps6_value = {ghconfig_ti_ps[5]}
-
 Ps1_factor = {ghconfig_ti_ps_factors[0]}
 Ps2_factor = {ghconfig_ti_ps_factors[1]}
 Ps3_factor = {ghconfig_ti_ps_factors[2]}

--- a/TEMPLATES/HMS/SCALERS/hscalers.template
+++ b/TEMPLATES/HMS/SCALERS/hscalers.template
@@ -28,13 +28,6 @@ Unser Counts: {H.Unser.scalerCut} 	Total Charge: {H.Unser.scalerChargeCut:%.3f} 
 * DAQ Configuration
 ********************
 
-Ps1_value = {ghconfig_ti_ps[0]}
-Ps2_value = {ghconfig_ti_ps[1]}
-Ps3_value = {ghconfig_ti_ps[2]}
-Ps4_value = {ghconfig_ti_ps[3]}
-Ps5_value = {ghconfig_ti_ps[4]}
-Ps6_value = {ghconfig_ti_ps[5]}
-
 Ps1_factor = {ghconfig_ti_ps_factors[0]}
 Ps2_factor = {ghconfig_ti_ps_factors[1]}
 Ps3_factor = {ghconfig_ti_ps_factors[2]}

--- a/TEMPLATES/HMS/SCALERS/hscalers.template
+++ b/TEMPLATES/HMS/SCALERS/hscalers.template
@@ -35,12 +35,12 @@ Ps4_value = {ghconfig_ti_ps[3]}
 Ps5_value = {ghconfig_ti_ps[4]}
 Ps6_value = {ghconfig_ti_ps[5]}
 
-Ps1_factor = {floor(2**(ghconfig_ti_ps[0] - 1) + 1):%d}
-Ps2_factor = {floor(2**(ghconfig_ti_ps[1] - 1) + 1):%d}
-Ps3_factor = {floor(2**(ghconfig_ti_ps[2] - 1) + 1):%d}
-Ps4_factor = {floor(2**(ghconfig_ti_ps[3] - 1) + 1):%d}
-Ps5_factor = {floor(2**(ghconfig_ti_ps[4] - 1) + 1):%d}
-Ps6_factor = {floor(2**(ghconfig_ti_ps[5] - 1) + 1):%d}
+Ps1_factor = {ghconfig_ti_ps_factors[0]}
+Ps2_factor = {ghconfig_ti_ps_factors[1]}
+Ps3_factor = {ghconfig_ti_ps_factors[2]}
+Ps4_factor = {ghconfig_ti_ps_factors[3]}
+Ps5_factor = {ghconfig_ti_ps_factors[4]}
+Ps6_factor = {ghconfig_ti_ps_factors[5]}
 
 ***********
 * Triggers

--- a/TEMPLATES/SHMS/PRODUCTION/pstackana_production.template
+++ b/TEMPLATES/SHMS/PRODUCTION/pstackana_production.template
@@ -32,12 +32,12 @@ Ps4_value = {gpconfig_ti_ps[3]}
 Ps5_value = {gpconfig_ti_ps[4]}
 Ps6_value = {gpconfig_ti_ps[5]}
 
-Ps1_factor = {floor(2**(gpconfig_ti_ps[0] - 1) + 1):%d}
-Ps2_factor = {floor(2**(gpconfig_ti_ps[1] - 1) + 1):%d}
-Ps3_factor = {floor(2**(gpconfig_ti_ps[2] - 1) + 1):%d}
-Ps4_factor = {floor(2**(gpconfig_ti_ps[3] - 1) + 1):%d}
-Ps5_factor = {floor(2**(gpconfig_ti_ps[4] - 1) + 1):%d}
-Ps6_factor = {floor(2**(gpconfig_ti_ps[5] - 1) + 1):%d}
+Ps1_factor = {ghconfig_ti_ps_factors[0]}
+Ps2_factor = {ghconfig_ti_ps_factors[1]}
+Ps3_factor = {ghconfig_ti_ps_factors[2]}
+Ps4_factor = {ghconfig_ti_ps_factors[3]}
+Ps5_factor = {ghconfig_ti_ps_factors[4]}
+Ps6_factor = {ghconfig_ti_ps_factors[5]}
 
 ***************	
 * 3/4 Triggers 

--- a/TEMPLATES/SHMS/PRODUCTION/pstackana_production.template
+++ b/TEMPLATES/SHMS/PRODUCTION/pstackana_production.template
@@ -25,13 +25,6 @@ Unser Counts: {P.Unser.scalerCut} 	Total Charge: {P.Unser.scalerChargeCut:%.3f} 
 * DAQ Configuration
 ********************
 
-Ps1_value = {gpconfig_ti_ps[0]}
-Ps2_value = {gpconfig_ti_ps[1]}
-Ps3_value = {gpconfig_ti_ps[2]}
-Ps4_value = {gpconfig_ti_ps[3]}
-Ps5_value = {gpconfig_ti_ps[4]}
-Ps6_value = {gpconfig_ti_ps[5]}
-
 Ps1_factor = {ghconfig_ti_ps_factors[0]}
 Ps2_factor = {ghconfig_ti_ps_factors[1]}
 Ps3_factor = {ghconfig_ti_ps_factors[2]}

--- a/TEMPLATES/SHMS/SCALERS/pscalers.template
+++ b/TEMPLATES/SHMS/SCALERS/pscalers.template
@@ -29,13 +29,6 @@ Unser Counts: {P.Unser.scalerCut} 	Total Charge: {P.Unser.scalerChargeCut:%.3f} 
 * DAQ Configuration
 ********************
 
-Ps1_value = {gpconfig_ti_ps[0]}
-Ps2_value = {gpconfig_ti_ps[1]}
-Ps3_value = {gpconfig_ti_ps[2]}
-Ps4_value = {gpconfig_ti_ps[3]}
-Ps5_value = {gpconfig_ti_ps[4]}
-Ps6_value = {gpconfig_ti_ps[5]}
-
 Ps1_factor = {ghconfig_ti_ps_factors[0]}
 Ps2_factor = {ghconfig_ti_ps_factors[1]}
 Ps3_factor = {ghconfig_ti_ps_factors[2]}

--- a/TEMPLATES/SHMS/SCALERS/pscalers.template
+++ b/TEMPLATES/SHMS/SCALERS/pscalers.template
@@ -36,12 +36,12 @@ Ps4_value = {gpconfig_ti_ps[3]}
 Ps5_value = {gpconfig_ti_ps[4]}
 Ps6_value = {gpconfig_ti_ps[5]}
 
-Ps1_factor = {floor(2**(gpconfig_ti_ps[0] - 1) + 1):%d}
-Ps2_factor = {floor(2**(gpconfig_ti_ps[1] - 1) + 1):%d}
-Ps3_factor = {floor(2**(gpconfig_ti_ps[2] - 1) + 1):%d}
-Ps4_factor = {floor(2**(gpconfig_ti_ps[3] - 1) + 1):%d}
-Ps5_factor = {floor(2**(gpconfig_ti_ps[4] - 1) + 1):%d}
-Ps6_factor = {floor(2**(gpconfig_ti_ps[5] - 1) + 1):%d}
+Ps1_factor = {ghconfig_ti_ps_factors[0]}
+Ps2_factor = {ghconfig_ti_ps_factors[1]}
+Ps3_factor = {ghconfig_ti_ps_factors[2]}
+Ps4_factor = {ghconfig_ti_ps_factors[3]}
+Ps5_factor = {ghconfig_ti_ps_factors[4]}
+Ps6_factor = {ghconfig_ti_ps_factors[5]}
 
 ***********	
 * 3/4 Triggers


### PR DESCRIPTION
Turned out the 'floor{...}' syntax doesn't work properly in ROOT 5.

This is better in the long run anyway.  Note that users will need to update hcana to get access to the new variables.