### PR TITLE
Modify PRODUCTION scripts and DEF-files

### DIFF
--- a/DEF-files/COIN/PRODUCTION/coin_production_hElec_pProt_cuts.def
+++ b/DEF-files/COIN/PRODUCTION/coin_production_hElec_pProt_cuts.def
@@ -62,6 +62,8 @@ ALL_COIN_NO_EDTM  T.coin.hEDTM_tdcTime==0.0&&T.coin.pEDTM_tdcTime==0.0&&ALL_even
 Decode_master     ALL_COIN_NO_EDTM
 
 Block: CoarseTracking
+#include "DEF-files/SHMS/PRODUCTION/pstackana_coarsetracking_cuts.def"
+#include "DEF-files/HMS/PRODUCTION/hstackana_coarsetracking_cuts.def"
 CoarseTracking_master ALL_COIN_NO_EDTM
 
 Block: CoarseReconstruct
@@ -71,6 +73,8 @@ Block: Tracking
 Tracking_master  ALL_COIN_NO_EDTM
 
 Block: Reconstruct
+#include "DEF-files/SHMS/PRODUCTION/pstackana_reconstruction_cuts.def"
+#include "DEF-files/HMS/PRODUCTION/hstackana_reconstruction_cuts.def"
 Reconstruct_master ALL_COIN_NO_EDTM
 
 hcleantrack        H.gtr.index > -1
@@ -87,5 +91,3 @@ select_e_cut       e_cut_cal && e_cut_cer
 betacut_proton     P.gtr.beta > 0.6 && P.gtr.beta < 0.8
 coincut_ep         ccleantrack && select_e_cut && betacut_proton
 
-#include "DEF-files/HMS/PRODUCTION/hstackana_production_cuts.def"
-#include "DEF-files/SHMS/PRODUCTION/pstackana_production_cuts.def"

--- a/DEF-files/HMS/PRODUCTION/hstackana_coarsetracking_cuts.def
+++ b/DEF-files/HMS/PRODUCTION/hstackana_coarsetracking_cuts.def
@@ -1,0 +1,90 @@
+#add cuts to stricter times and apply them to drift distances (HMS 6 GeV Drift Chambers)
+hcut_time_cut1                            H.dc.1x1.time > 0 && H.dc.1x1.time < 250
+hcut_time_cut2                            H.dc.1v2.time > 0 && H.dc.1v2.time < 250
+hcut_time_cut3                            H.dc.1u1.time > 0 && H.dc.1u1.time < 250
+hcut_time_cut4                            H.dc.1v1.time > 0 && H.dc.1v1.time < 250
+hcut_time_cut5                            H.dc.1u2.time > 0 && H.dc.1u2.time < 250
+hcut_time_cut6                            H.dc.1x2.time > 0 && H.dc.1x2.time < 250
+hcut_time_cut7                            H.dc.2x1.time > 0 && H.dc.2x1.time < 250
+hcut_time_cut8                            H.dc.2v2.time > 0 && H.dc.1v2.time < 250
+hcut_time_cut9                            H.dc.2u1.time > 0 && H.dc.2u1.time < 250
+hcut_time_cut10                           H.dc.2v1.time > 0 && H.dc.2v1.time < 250
+hcut_time_cut11                           H.dc.2u2.time > 0 && H.dc.2u2.time < 250
+hcut_time_cut12                           H.dc.2x2.time > 0 && H.dc.2x2.time < 250
+
+hmsDC1Planes_large  (H.dc.1x1.nhit+H.dc.1v2.nhit+H.dc.1u1.nhit+H.dc.1v1.nhit+H.dc.1x2.nhit+H.dc.1u2.nhit) >20
+hmsDC2Planes_large  (H.dc.2x1.nhit+H.dc.2v2.nhit+H.dc.2u1.nhit+H.dc.2v1.nhit+H.dc.2x2.nhit+H.dc.2u2.nhit) >20
+hmsDCany_large 	    hmsDC1Planes_large || hmsDC2Planes_large 
+
+hmsDC1_1hit_x1                H.dc.1x1.nhit == 1
+hmsDC1_1hit_v2                H.dc.1v2.nhit == 1
+hmsDC1_1hit_u1                H.dc.1u1.nhit == 1
+hmsDC1_1hit_v1                H.dc.1v1.nhit == 1
+hmsDC1_1hit_u2                H.dc.1u2.nhit == 1
+hmsDC1_1hit_x2                H.dc.1x2.nhit == 1
+
+hmsDC2_1hit_x1                H.dc.2x1.nhit == 1
+hmsDC2_1hit_v2                H.dc.2v2.nhit == 1
+hmsDC2_1hit_u1                H.dc.2u1.nhit == 1
+hmsDC2_1hit_v1                H.dc.2v1.nhit == 1
+hmsDC2_1hit_u2                H.dc.2u2.nhit == 1
+hmsDC2_1hit_x2                H.dc.2x2.nhit == 1
+
+h1hit1                H.dc.1x1.nhit >= 1
+h1hit2                H.dc.1v2.nhit >= 1
+h1hit3                H.dc.1u1.nhit >= 1
+h1hit4                H.dc.1v1.nhit >= 1
+h1hit5                H.dc.1u2.nhit >= 1
+h1hit6                H.dc.1x2.nhit >= 1
+
+h2hit1                H.dc.2x1.nhit >= 1
+h2hit2                H.dc.2v2.nhit >= 1
+h2hit3                H.dc.2u1.nhit >= 1
+h2hit4                H.dc.2v1.nhit >= 1
+h2hit5                H.dc.2u2.nhit >= 1
+h2hit6                H.dc.2x2.nhit >= 1
+
+hmsDC1Planes6hits   (H.dc.1x1.nhit+H.dc.1v2.nhit+H.dc.1u1.nhit+H.dc.1v1.nhit+H.dc.1x2.nhit+H.dc.1u2.nhit) ==6
+hmsDC2Planes6hits   (H.dc.2x1.nhit+H.dc.2v2.nhit+H.dc.2u1.nhit+H.dc.2v1.nhit+H.dc.2x2.nhit+H.dc.2u2.nhit )==6
+hmsDC1_5hits_x1     hmsDC1_1hit_v2&&hmsDC1_1hit_u1&&hmsDC1_1hit_v1&&hmsDC1_1hit_x2&&hmsDC1_1hit_u2
+hmsDC1_6hits_x1     h1hit1&&hmsDC1_1hit_v2&&hmsDC1_1hit_u1&&hmsDC1_1hit_v1&&hmsDC1_1hit_x2&&hmsDC1_1hit_u2
+hmsDC1_5hits_v2     hmsDC1_1hit_x1&&hmsDC1_1hit_u1&&hmsDC1_1hit_v1&&hmsDC1_1hit_x2&&hmsDC1_1hit_u2
+hmsDC1_6hits_v2     h1hit2&&hmsDC1_1hit_x1&&hmsDC1_1hit_u1&&hmsDC1_1hit_v1&&hmsDC1_1hit_x2&&hmsDC1_1hit_u2
+hmsDC1_5hits_u1     hmsDC1_1hit_x1&&hmsDC1_1hit_v2&&hmsDC1_1hit_v1&&hmsDC1_1hit_x2&&hmsDC1_1hit_u2
+hmsDC1_6hits_u1     h1hit3&&hmsDC1_1hit_x1&&hmsDC1_1hit_v2&&hmsDC1_1hit_v1&&hmsDC1_1hit_x2&&hmsDC1_1hit_u2
+hmsDC1_5hits_v1     hmsDC1_1hit_x1&&hmsDC1_1hit_v2&&hmsDC1_1hit_u1&&hmsDC1_1hit_x2&&hmsDC1_1hit_u2 
+hmsDC1_6hits_v1     h1hit4&&hmsDC1_1hit_x1&&hmsDC1_1hit_v2&&hmsDC1_1hit_u1&&hmsDC1_1hit_x2&&hmsDC1_1hit_u2
+hmsDC1_5hits_x2     hmsDC1_1hit_x1&&hmsDC1_1hit_v2&&hmsDC1_1hit_u1&&hmsDC1_1hit_v1&&hmsDC1_1hit_u2
+hmsDC1_6hits_x2     h1hit6&&hmsDC1_1hit_x1&&hmsDC1_1hit_v2&&hmsDC1_1hit_u1&&hmsDC1_1hit_v1&&hmsDC1_1hit_u2
+hmsDC1_5hits_u2     hmsDC1_1hit_x1&&hmsDC1_1hit_v2&&hmsDC1_1hit_u1&&hmsDC1_1hit_v1&&hmsDC1_1hit_x2
+hmsDC1_6hits_u2     h1hit5&&hmsDC1_1hit_x1&&hmsDC1_1hit_v2&&hmsDC1_1hit_u1&&hmsDC1_1hit_v1&&hmsDC1_1hit_x2
+
+hmsDC2_5hits_x1     hmsDC2_1hit_v2&&hmsDC2_1hit_u1&&hmsDC2_1hit_v1&&hmsDC2_1hit_x2&&hmsDC2_1hit_u2
+hmsDC2_6hits_x1     h2hit1&&hmsDC2_1hit_v2&&hmsDC2_1hit_u1&&hmsDC2_1hit_v1&&hmsDC2_1hit_x2&&hmsDC2_1hit_u2
+hmsDC2_5hits_v2     hmsDC2_1hit_x1&&hmsDC2_1hit_u1&&hmsDC2_1hit_v1&&hmsDC2_1hit_x2&&hmsDC2_1hit_u2
+hmsDC2_6hits_v2     h2hit2&&hmsDC2_1hit_x1&&hmsDC2_1hit_u1&&hmsDC2_1hit_v1&&hmsDC2_1hit_x2&&hmsDC2_1hit_u2
+hmsDC2_5hits_u1     hmsDC2_1hit_x1&&hmsDC2_1hit_v2&&hmsDC2_1hit_v1&&hmsDC2_1hit_x2&&hmsDC2_1hit_u2
+hmsDC2_6hits_u1     h2hit3&&hmsDC2_1hit_x1&&hmsDC2_1hit_v2&&hmsDC2_1hit_v1&&hmsDC2_1hit_x2&&hmsDC2_1hit_u2
+hmsDC2_5hits_v1     hmsDC2_1hit_x1&&hmsDC2_1hit_v2&&hmsDC2_1hit_u1&&hmsDC2_1hit_x2&&hmsDC2_1hit_u2 
+hmsDC2_6hits_v1     h2hit4&&hmsDC2_1hit_x1&&hmsDC2_1hit_v2&&hmsDC2_1hit_u1&&hmsDC2_1hit_x2&&hmsDC2_1hit_u2
+hmsDC2_5hits_x2     hmsDC2_1hit_x1&&hmsDC2_1hit_v2&&hmsDC2_1hit_u1&&hmsDC2_1hit_v1&&hmsDC2_1hit_u2
+hmsDC2_6hits_x2     h2hit6&&hmsDC2_1hit_x1&&hmsDC2_1hit_v2&&hmsDC2_1hit_u1&&hmsDC2_1hit_v1&&hmsDC2_1hit_u2
+hmsDC2_5hits_u2     hmsDC2_1hit_x1&&hmsDC2_1hit_v2&&hmsDC2_1hit_u1&&hmsDC2_1hit_v1&&hmsDC2_1hit_x2
+hmsDC2_6hits_u2     h2hit5&&hmsDC2_1hit_x1&&hmsDC2_1hit_v2&&hmsDC2_1hit_u1&&hmsDC2_1hit_v1&&hmsDC2_1hit_x2
+
+hms1HitsLt            H.dc.Ch1.nhit <= H.dc.Ch1.maxhits && g.evtyp==1
+hms2HitsLt            H.dc.Ch2.nhit <= H.dc.Ch2.maxhits && g.evtyp==1
+hmsHitsLt             H.dc.Ch1.nhit <= H.dc.Ch1.maxhits && H.dc.Ch2.nhit <= H.dc.Ch2.maxhits && g.evtyp==1
+hmsDC1PlanesGT        (h1hit1 + h1hit2 + h1hit3 + h1hit4 + h1hit5 + h1hit6 )>=5
+hmsDC2PlanesGT        (h2hit1 + h2hit2 + h2hit3 + h2hit4 + h2hit5 + h2hit6 )>=5
+hmsPlanesGT           hmsDC1PlanesGT && hmsDC2PlanesGT
+hmsHitsPlanes         (H.dc.Ch1.nhit <= H.dc.Ch1.maxhits) && (H.dc.Ch2.nhit <= H.dc.Ch2.maxhits) && hmsPlanesGT
+hSpacePoints          H.dc.Ch1.spacepoints >= 1 && H.dc.Ch2.spacepoints >=1
+hSpacePointsStub      H.dc.stubtest==1 && H.dc.Ch1.spacepoints >=1 && H.dc.Ch2.spacepoints >=1
+hFoundTrack           H.dc.ntrack>0 
+hStubLT               H.dc.stubtest==1
+f1HSpacePoints        hms1HitsLt && hmsDC1PlanesGT && H.dc.Ch1.spacepoints==0 && g.evtyp==1
+f2HSpacePoints        hms2HitsLt && hmsDC2PlanesGT && H.dc.Ch2.spacepoints==0 && g.evtyp==1
+hTest1                hmsHitsPlanes && (!hSpacePoints)
+hTest2                hSpacePoints && (!hStubLT)
+

--- a/DEF-files/HMS/PRODUCTION/hstackana_reconstruction_cuts.def
+++ b/DEF-files/HMS/PRODUCTION/hstackana_reconstruction_cuts.def
@@ -1,0 +1,79 @@
+hcut_cer_pmt1_elec        H.cer.npe[0]>.5
+hcut_cer_pmt2_elec        H.cer.npe[0]>.5
+hcut_cer_elec       	  H.cer.npeSum>.5
+hcut_cer_pi       	  H.cer.npeSum<.5
+
+HMSScinGood           H.hod.goodscinhit == 1
+HMSGoodBetanotrk      H.hod.betanotrack > 0.8 && H.hod.betanotrack < 1.3
+
+
+HMSScinShould         HMSScinGood && HMSGoodBetanotrk && !hmsDCany_large
+HMSScinShoulde        HMSScinShould && H.cal.etotnorm > 0.6&& H.cal.etotnorm < 2.0&& H.cer.npeSum > 0.5
+HMSScinShouldh        HMSScinGood && H.cal.etotnorm <0.6&& H.cal.etotnorm>0.0&& H.cer.npeSum < 0.5
+
+HMSScinDid            HMSScinShould && H.dc.ntrack > 0
+HMSScinDide           HMSScinShoulde && H.dc.ntrack > 0
+HMSScinDidh           HMSScinShouldh && H.dc.ntrack > 0
+
+hcut_goodHDC1x1            H.dc.1x1.nhit > 0 && H.dc.1x1.nhit < 3
+hcut_goodHDC1v2            H.dc.1v2.nhit > 0 && H.dc.1v2.nhit < 3
+hcut_goodHDC1u1            H.dc.1u1.nhit > 0 && H.dc.1u1.nhit < 3
+hcut_goodHDC1v1            H.dc.1v1.nhit > 0 && H.dc.1v1.nhit < 3
+hcut_goodHDC1u2            H.dc.1u2.nhit > 0 && H.dc.1u2.nhit < 3
+hcut_goodHDC1x2            H.dc.1x2.nhit > 0 && H.dc.1x2.nhit < 3
+
+hcut_goodHDC2x1            H.dc.2x1.nhit > 0 && H.dc.2x1.nhit < 3
+hcut_goodHDC2v2            H.dc.2v2.nhit > 0 && H.dc.2v2.nhit < 3
+hcut_goodHDC2u1            H.dc.2u1.nhit > 0 && H.dc.2u1.nhit < 3
+hcut_goodHDC2v1            H.dc.2v1.nhit > 0 && H.dc.2v1.nhit < 3
+hcut_goodHDC2u2            H.dc.2u2.nhit > 0 && H.dc.2u2.nhit < 3
+hcut_goodHDC2x2            H.dc.2x2.nhit > 0 && H.dc.2x2.nhit < 3
+
+hcut_goodHDC1              hcut_goodHDC1x1  && hcut_goodHDC1v2 && hcut_goodHDC1u1 && hcut_goodHDC1v1 && hcut_goodHDC1u2 && hcut_goodHDC1x2 
+hcut_goodHDC2              hcut_goodHDC2x1  && hcut_goodHDC2v2 && hcut_goodHDC2u1 && hcut_goodHDC2v1 && hcut_goodHDC2u2 && hcut_goodHDC2x2 
+hcut_bothGood              hcut_goodHDC1 && hcut_goodHDC2
+
+hcut_realhdc1x1            hcut_goodHDC1x1 && ((H.dc.Ch1.spacepoints+H.dc.Ch2.spacepoints)>0)
+hcut_realhdc1v2            hcut_goodHDC1v2 && ((H.dc.Ch1.spacepoints+H.dc.Ch2.spacepoints)>0)
+hcut_realhdc1u1            hcut_goodHDC1u1 && ((H.dc.Ch1.spacepoints+H.dc.Ch2.spacepoints)>0)
+hcut_realhdc1v1            hcut_goodHDC1v1 && ((H.dc.Ch1.spacepoints+H.dc.Ch2.spacepoints)>0)
+hcut_realhdc1u2            hcut_goodHDC1u2 && ((H.dc.Ch1.spacepoints+H.dc.Ch2.spacepoints)>0)
+hcut_realhdc1x2            hcut_goodHDC1x2 && ((H.dc.Ch1.spacepoints+H.dc.Ch2.spacepoints)>0)
+hcut_realhdc2x1            hcut_goodHDC2x1 && ((H.dc.Ch1.spacepoints+H.dc.Ch2.spacepoints)>0)
+hcut_realhdc2v2            hcut_goodHDC2v2 && ((H.dc.Ch1.spacepoints+H.dc.Ch2.spacepoints)>0)
+hcut_realhdc2u1     	   hcut_goodHDC2u1 && ((H.dc.Ch1.spacepoints+H.dc.Ch2.spacepoints)>0)
+hcut_realhdc2v1            hcut_goodHDC2v1 && ((H.dc.Ch1.spacepoints+H.dc.Ch2.spacepoints)>0)
+hcut_realhdc2u2            hcut_goodHDC2u2 && ((H.dc.Ch1.spacepoints+H.dc.Ch2.spacepoints)>0)
+hcut_realhdc2x2            hcut_goodHDC2x2 && ((H.dc.Ch1.spacepoints+H.dc.Ch2.spacepoints)>0)
+
+hcut_FoundTrack      	   H.dc.ntrack > 0
+hcut_Found1Track           H.dc.ntrack == 1
+hcut_Found2Track           H.dc.ntrack == 2
+hcut_Found3Track           H.dc.ntrack == 3
+hcut_Found4Track           H.dc.ntrack == 4
+
+hcut_CleanTrack            H.gtr.index > -1
+hcut_Clean1Track           H.gtr.index == 0
+hcut_Clean2Track           H.gtr.index == 1
+hcut_Clean3Track           H.gtr.index == 2
+hcut_Clean4Track           H.gtr.index == 3
+
+hcut_anys1x                H.hod.1x.nhits > 0
+hcut_anys1y                H.hod.1y.nhits > 0
+hcut_anys2x                H.hod.2x.nhits > 0
+hcut_anys2y                H.hod.2y.nhits > 0
+
+hcut_goods1x               H.hod.1x.nhits > 0 && H.hod.1x.nhits < 3
+hcut_goods1y               H.hod.1y.nhits > 0 && H.hod.1y.nhits < 3
+hcut_goods1                hcut_goods1x && hcut_goods1y
+hcut_goods2x               H.hod.2x.nhits > 0 && H.hod.2x.nhits < 3
+hcut_goods2y               H.hod.2y.nhits > 0 && H.hod.2y.nhits < 3
+hcut_goods2                hcut_goods2x && hcut_goods2y
+hcut_goods1s2              hcut_goods1 && hcut_goods2
+
+HMS_hcer_track_matched_region_1 H.cer.numTracksMatched[0]>0
+HMS_hcer_track_fired_region_1 H.cer.numTracksFired[0]>0
+HMS_hcer_track_matched_region_2 H.cer.numTracksMatched[1]>0
+HMS_hcer_track_fired_region_2 H.cer.numTracksFired[1]>0
+HMS_hcer_track_matched_tot H.cer.totNumTracksMatched>0
+HMS_hcer_track_fired_tot H.cer.totNumTracksFired>0

--- a/DEF-files/SHMS/PRODUCTION/pstackana_coarsetracking_cuts.def
+++ b/DEF-files/SHMS/PRODUCTION/pstackana_coarsetracking_cuts.def
@@ -1,0 +1,114 @@
+# Add cuts to stricter times and apply them to drift distances 
+pcut_time_cut1      P.dc.1u1.time > 0 && P.dc.1u1.time < 250
+pcut_time_cut2      P.dc.1u2.time > 0 && P.dc.1u2.time < 250
+pcut_time_cut3      P.dc.1x1.time > 0 && P.dc.1x1.time < 250
+pcut_time_cut4      P.dc.1x2.time > 0 && P.dc.1x2.time < 250
+pcut_time_cut5      P.dc.1v1.time > 0 && P.dc.1v1.time < 250
+pcut_time_cut6      P.dc.1v2.time > 0 && P.dc.1v2.time < 250
+pcut_time_cut7      P.dc.2v2.time > 0 && P.dc.2v2.time < 250
+pcut_time_cut8      P.dc.2v1.time > 0 && P.dc.2v1.time < 250
+pcut_time_cut9      P.dc.2x2.time > 0 && P.dc.2x2.time < 250
+pcut_time_cut10     P.dc.2x1.time > 0 && P.dc.2x1.time < 250
+pcut_time_cut11     P.dc.2u2.time > 0 && P.dc.2u2.time < 250
+pcut_time_cut12     P.dc.2u1.time > 0 && P.dc.2u1.time < 250
+
+shmsDC1Planes_large     (P.dc.1x1.nhit + P.dc.1u2.nhit + P.dc.1u1.nhit + P.dc.1v1.nhit + P.dc.1x2.nhit + P.dc.1v2.nhit) > 20
+shmsDC2Planes_large     (P.dc.2x1.nhit + P.dc.2u2.nhit + P.dc.2u1.nhit + P.dc.2v1.nhit + P.dc.2x2.nhit + P.dc.2v2.nhit) > 20 
+shmsDCany_large        shmsDC1Planes_large || shmsDC2Planes_large
+			
+shms_ch1_gt0           P.dc.Ch1.nhit > 0
+shms_ch2_gt0           P.dc.Ch2.nhit > 0
+shms_ch_gt0            P.dc.Ch2.nhit > 0  && P.dc.Ch1.nhit > 0
+shms_ch_gt4            P.dc.Ch2.nhit > 3  && P.dc.Ch1.nhit > 3
+shms_ch2_gt0_noch1     P.dc.Ch2.nhit > 0  && P.dc.Ch1.nhit == 0
+shms_ch1_gt0_noch2     P.dc.Ch1.nhit > 0  && P.dc.Ch2.nhit == 0
+shms_noch1_noch2       P.dc.Ch1.nhit == 0 && P.dc.Ch2.nhit == 0
+shms_ch_gt0_track      shms_ch_gt0 && P.dc.ntrack > 0
+shms_ch_gt4_track      shms_ch_gt4 && P.dc.ntrack > 0
+
+shms_ch1_gt0_gtime           P.dc.Ch1.nhit > 0 && pcut_good_S1_S2X_time
+shms_ch2_gt0_gtime           P.dc.Ch2.nhit > 0 && pcut_good_S1_S2X_time
+shms_ch_gt0_gtime            P.dc.Ch2.nhit > 0 && P.dc.Ch1.nhit > 0 && pcut_good_S1_S2X_time
+shms_ch_gt4_gtime            P.dc.Ch2.nhit > 3 && P.dc.Ch1.nhit > 3 && pcut_good_S1_S2X_time
+shms_ch2_gt0_noch1_gtime     P.dc.Ch2.nhit > 0 && P.dc.Ch1.nhit == 0 && pcut_good_S1_S2X_time
+shms_ch1_gt0_noch2_gtime     P.dc.Ch1.nhit > 0 && P.dc.Ch2.nhit == 0 && pcut_good_S1_S2X_time
+shms_noch1_noch2_gtime       P.dc.Ch1.nhit == 0 && P.dc.Ch2.nhit == 0 && pcut_good_S1_S2X_time
+shms_ch_gt0_track_gtime      shms_ch_gt0 && P.dc.ntrack > 0 && pcut_good_S1_S2X_time
+shms_ch_gt4_track_gtime      shms_ch_gt4 && P.dc.ntrack > 0 && pcut_good_S1_S2X_time
+
+shmsDC1_1hit_x1     P.dc.1x1.nhit == 1
+shmsDC1_1hit_u1     P.dc.1u1.nhit == 1
+shmsDC1_1hit_u2     P.dc.1u2.nhit == 1
+shmsDC1_1hit_v1     P.dc.1v1.nhit == 1
+shmsDC1_1hit_v2     P.dc.1v2.nhit == 1
+shmsDC1_1hit_x2     P.dc.1x2.nhit == 1
+
+shmsDC2_1hit_x1     P.dc.2x1.nhit == 1
+shmsDC2_1hit_u1	    P.dc.2u1.nhit == 1
+shmsDC2_1hit_u2     P.dc.2u2.nhit == 1
+shmsDC2_1hit_v1     P.dc.2v1.nhit == 1
+shmsDC2_1hit_v2     P.dc.2v2.nhit == 1
+shmsDC2_1hit_x2     P.dc.2x2.nhit == 1
+
+p1hit1     P.dc.1x1.nhit >= 1
+p1hit2     P.dc.1u1.nhit >= 1
+p1hit3     P.dc.1u2.nhit >= 1
+p1hit4     P.dc.1v1.nhit >= 1
+p1hit5     P.dc.1v2.nhit >= 1
+p1hit6     P.dc.1x2.nhit >= 1
+
+p2hit1     P.dc.2x1.nhit >= 1
+p2hit2     P.dc.2u1.nhit >= 1
+p2hit3     P.dc.2u2.nhit >= 1
+p2hit4     P.dc.2v1.nhit >= 1
+p2hit5     P.dc.2v2.nhit >= 1
+p2hit6     P.dc.2x2.nhit >= 1
+
+shmsDC1Planes6hits     shmsDC1_1hit_x1 && shmsDC1_1hit_u1 && shmsDC1_1hit_u2 && shmsDC1_1hit_x2 && shmsDC1_1hit_v1 && shmsDC1_1hit_v2
+shmsDC2Planes6hits     shmsDC2_1hit_x1 && shmsDC2_1hit_u1 && shmsDC2_1hit_u2 && shmsDC2_1hit_x2 && shmsDC2_1hit_v1 && shmsDC2_1hit_v2
+
+shmsDC1_5hits_x1     shmsDC1_1hit_u1 && shmsDC1_1hit_u2 && shmsDC1_1hit_x2 && shmsDC1_1hit_v1 && shmsDC1_1hit_v2
+shmsDC1_6hits_x1     p1hit1 && shmsDC1_1hit_u1 && shmsDC1_1hit_u2 && shmsDC1_1hit_x2 && shmsDC1_1hit_v1 && shmsDC1_1hit_v2
+shmsDC1_5hits_u1     shmsDC1_1hit_x1 && shmsDC1_1hit_u2 && shmsDC1_1hit_x2 && shmsDC1_1hit_v1 && shmsDC1_1hit_v2
+shmsDC1_6hits_u1     p1hit2 && shmsDC1_1hit_x1 && shmsDC1_1hit_u2 && shmsDC1_1hit_x2 && shmsDC1_1hit_v1 && shmsDC1_1hit_v2
+shmsDC1_5hits_u2     shmsDC1_1hit_x1 && shmsDC1_1hit_u1 && shmsDC1_1hit_x2 && shmsDC1_1hit_v1 && shmsDC1_1hit_v2
+shmsDC1_6hits_u2     p1hit3 && shmsDC1_1hit_x1 && shmsDC1_1hit_u1 && shmsDC1_1hit_x2 && shmsDC1_1hit_v1 && shmsDC1_1hit_v2
+shmsDC1_5hits_v1     shmsDC1_1hit_x1 && shmsDC1_1hit_u1 && shmsDC1_1hit_x2 && shmsDC1_1hit_u2 && shmsDC1_1hit_v2
+shmsDC1_6hits_v1     p1hit4 && shmsDC1_1hit_x1 && shmsDC1_1hit_u1 && shmsDC1_1hit_x2 && shmsDC1_1hit_u2 && shmsDC1_1hit_v2
+shmsDC1_5hits_v2     shmsDC1_1hit_x1 && shmsDC1_1hit_u1 && shmsDC1_1hit_x2 && shmsDC1_1hit_u2 && shmsDC1_1hit_v1
+shmsDC1_6hits_v2     p1hit5 && shmsDC1_1hit_x1 && shmsDC1_1hit_u1 && shmsDC1_1hit_x2 && shmsDC1_1hit_u2 && shmsDC1_1hit_v1
+shmsDC1_5hits_x2     shmsDC1_1hit_x1 && shmsDC1_1hit_u1 && shmsDC1_1hit_v1 && shmsDC1_1hit_u2 && shmsDC1_1hit_v2
+shmsDC1_6hits_x2     p1hit6 && shmsDC1_1hit_x1 && shmsDC1_1hit_u1 && shmsDC1_1hit_v1 && shmsDC1_1hit_u2 && shmsDC1_1hit_v2
+
+shmsDC2_5hits_x1     shmsDC2_1hit_u1 && shmsDC2_1hit_u2 && shmsDC2_1hit_x2 && shmsDC2_1hit_v1 && shmsDC2_1hit_v2
+shmsDC2_6hits_x1     p2hit1 && shmsDC2_1hit_u1 && shmsDC2_1hit_u2 && shmsDC2_1hit_x2 && shmsDC2_1hit_v1 && shmsDC2_1hit_v2
+shmsDC2_5hits_u1     shmsDC2_1hit_x1 && shmsDC2_1hit_u2 && shmsDC2_1hit_x2 && shmsDC2_1hit_v1 && shmsDC2_1hit_v2
+shmsDC2_6hits_u1     p2hit2 && shmsDC2_1hit_x1 && shmsDC2_1hit_u2 && shmsDC2_1hit_x2 && shmsDC2_1hit_v1 && shmsDC2_1hit_v2
+shmsDC2_5hits_u2     shmsDC2_1hit_x1 && shmsDC2_1hit_u1 && shmsDC2_1hit_x2 && shmsDC2_1hit_v1 && shmsDC2_1hit_v2
+shmsDC2_6hits_u2     p2hit3 && shmsDC2_1hit_x1 && shmsDC2_1hit_u1 && shmsDC2_1hit_x2 && shmsDC2_1hit_v1 && shmsDC2_1hit_v2
+shmsDC2_5hits_v1     shmsDC2_1hit_x1 && shmsDC2_1hit_u1 && shmsDC2_1hit_x2 && shmsDC2_1hit_u2 && shmsDC2_1hit_v2
+shmsDC2_6hits_v1     p2hit4 && shmsDC2_1hit_x1 && shmsDC2_1hit_u1 && shmsDC2_1hit_x2 && shmsDC2_1hit_u2 && shmsDC2_1hit_v2
+shmsDC2_5hits_v2     shmsDC2_1hit_x1 && shmsDC2_1hit_u1 && shmsDC2_1hit_x2 && shmsDC2_1hit_u2 && shmsDC2_1hit_v1
+shmsDC2_6hits_v2     p2hit5 && shmsDC2_1hit_x1 && shmsDC2_1hit_u1 && shmsDC2_1hit_x2 && shmsDC2_1hit_u2 && shmsDC2_1hit_v1
+shmsDC2_5hits_x2     shmsDC2_1hit_x1 && shmsDC2_1hit_u1 && shmsDC2_1hit_v1 && shmsDC2_1hit_u2 && shmsDC2_1hit_v2
+shmsDC2_6hits_x2     p2hit6 && shmsDC2_1hit_x1 && shmsDC2_1hit_u1 && shmsDC2_1hit_v1 && shmsDC2_1hit_u2 && shmsDC2_1hit_v2
+
+shms1HitsLt     P.dc.Ch1.nhit <= P.dc.Ch1.maxhits && g.evtyp == 1
+shms2HitsLt     P.dc.Ch2.nhit <= P.dc.Ch2.maxhits && g.evtyp == 1
+shmsHitsLt      P.dc.Ch1.nhit <= P.dc.Ch1.maxhits && P.dc.Ch2.nhit <= P.dc.Ch2.maxhits && g.evtyp == 1
+
+shmsDC1PlanesGT     (p1hit1 + p1hit2 + p1hit3 + p1hit4 + p1hit5 + p1hit6 ) >= 5
+shmsDC2PlanesGT     (p2hit1 + p2hit2 + p2hit3 + p2hit4 + p2hit5 + p2hit6 ) >= 5
+shmsPlanesGT        shmsDC1PlanesGT && shmsDC2PlanesGT
+shmsHitsPlanes      (P.dc.Ch1.nhit <= 6) && (P.dc.Ch2.nhit <= 6) && shmsPlanesGT
+
+pSpacePoints         P.dc.Ch1.spacepoints >= 1 && P.dc.Ch2.spacepoints >= 1
+pSpacePointsStub     P.dc.stubtest == 1 && P.dc.Ch1.spacepoints >= 1 && P.dc.Ch2.spacepoints >= 1
+pcut_FoundTrack      P.dc.ntrack > 0 
+pStubLT              P.dc.stubtest == 1
+f1PSpacePoints       shms1HitsLt && shmsDC1PlanesGT && P.dc.Ch1.spacepoints == 0 && g.evtyp == 1
+f2PSpacePoints       shms2HitsLt && shmsDC2PlanesGT && P.dc.Ch2.spacepoints == 0 && g.evtyp == 1
+
+pTest1     shmsHitsPlanes && (!pSpacePoints)
+pTest2	   pSpacePoints && (!pStubLT)
+

--- a/DEF-files/SHMS/PRODUCTION/pstackana_reconstruction_cuts.def
+++ b/DEF-files/SHMS/PRODUCTION/pstackana_reconstruction_cuts.def
@@ -1,0 +1,120 @@
+pcut_cer_ng_elec    	  P.ngcer.npeSum > 0.5
+pcut_cer_ng_pi      	  P.ngcer.npeSum <= 0.5
+pcut_cer_hg_elec	  P.hgcer.npeSum > 0.5
+pcut_cer_hg_pi	  	  P.hgcer.npeSum <= 0.5
+pcut_cer_pi_both       	  pcut_cer_ng_pi && pcut_cer_hg_pi
+pcut_cer_elec_both     	  pcut_cer_ng_elec && pcut_cer_hg_elec
+pcut_cal_elec          	  P.cal.etracknorm > 0.6 && P.cal.etracknorm < 1.6
+pcut_cal_pi            	  P.cal.etracknorm <= 0.6 && P.cal.etracknorm > 0.
+pcut_elec_all          	  pcut_cer_ng_elec && pcut_cer_hg_elec && pcut_cal_elec
+pcut_pi_all            	  pcut_cer_ng_pi && pcut_cer_hg_pi && pcut_cal_pi
+
+shmsScinGood        P.hod.goodscinhit == 1
+shmsGoodBetanotrk   P.hod.betanotrack > 0.5 && P.hod.betanotrack < 1.4
+
+shmsScinShould      shmsScinGood && shmsGoodBetanotrk && !shmsDCany_large 
+shmsScinShoulde     shmsScinShould &&  P.cal.etotnorm > 0.6 && P.cal.etotnorm < 1.6 && P.hgcer.npeSum > 0.5
+shmsScinShouldh     shmsScinShould && P.cal.etotnorm <= 0.6 && P.cal.etotnorm > 0. && P.hgcer.npeSum < 0.2
+shmsScinDid         shmsScinShould && P.dc.ntrack > 0
+shmsScinDide        shmsScinShoulde && P.dc.ntrack > 0
+shmsScinDidh        shmsScinShouldh && P.dc.ntrack > 0
+
+pcut_goodHDC1x1     P.dc.1x1.nhit > 0 && P.dc.1x1.nhit < 3
+pcut_goodHDC1u2     P.dc.1u2.nhit > 0 && P.dc.1u2.nhit < 3
+pcut_goodHDC1u1     P.dc.1u1.nhit > 0 && P.dc.1u1.nhit < 3
+pcut_goodHDC1v1     P.dc.1v1.nhit > 0 && P.dc.1v1.nhit < 3
+pcut_goodHDC1v2     P.dc.1v2.nhit > 0 && P.dc.1v2.nhit < 3
+pcut_goodHDC1x2     P.dc.1x2.nhit > 0 && P.dc.1x2.nhit < 3
+
+pcut_goodHDC2x1     P.dc.2x1.nhit > 0 && P.dc.2x1.nhit < 3
+pcut_goodHDC2u2     P.dc.2u2.nhit > 0 && P.dc.2u2.nhit < 3
+pcut_goodHDC2u1     P.dc.2u1.nhit > 0 && P.dc.2u1.nhit < 3
+pcut_goodHDC2v1     P.dc.2v1.nhit > 0 && P.dc.2v1.nhit < 3
+pcut_goodHDC2v2     P.dc.2v2.nhit > 0 && P.dc.2v2.nhit < 3
+pcut_goodHDC2x2     P.dc.2x2.nhit > 0 && P.dc.2x2.nhit < 3
+
+pcut_goodHDC1     pcut_goodHDC1x1  && pcut_goodHDC1u2 && pcut_goodHDC1u1 && pcut_goodHDC1v1 && pcut_goodHDC1v2 && pcut_goodHDC1x2 
+pcut_goodHDC2     pcut_goodHDC2x1  && pcut_goodHDC2u2 && pcut_goodHDC2u1 && pcut_goodHDC2v1 && pcut_goodHDC2v2 && pcut_goodHDC2x2 
+pcut_bothGood     pcut_goodHDC1 && pcut_goodHDC2
+
+pcut_realhdc1x1     pcut_goodHDC1x1 && ((P.dc.Ch1.spacepoints + P.dc.Ch2.spacepoints) > 0)
+pcut_realhdc1u2     pcut_goodHDC1u2 && ((P.dc.Ch1.spacepoints + P.dc.Ch2.spacepoints) > 0)
+pcut_realhdc1u1     pcut_goodHDC1u1 && ((P.dc.Ch1.spacepoints + P.dc.Ch2.spacepoints) > 0)
+pcut_realhdc1v1     pcut_goodHDC1v1 && ((P.dc.Ch1.spacepoints + P.dc.Ch2.spacepoints) > 0)
+pcut_realhdc1v2     pcut_goodHDC1v2 && ((P.dc.Ch1.spacepoints + P.dc.Ch2.spacepoints) > 0)
+pcut_realhdc1x2     pcut_goodHDC1x2 && ((P.dc.Ch1.spacepoints + P.dc.Ch2.spacepoints) > 0)
+
+pcut_realhdc2x1     pcut_goodHDC2x1 && ((P.dc.Ch1.spacepoints + P.dc.Ch2.spacepoints) > 0)
+pcut_realhdc2u2     pcut_goodHDC2u2 && ((P.dc.Ch1.spacepoints + P.dc.Ch2.spacepoints) > 0)
+pcut_realhdc2u1     pcut_goodHDC2u1 && ((P.dc.Ch1.spacepoints + P.dc.Ch2.spacepoints) > 0)
+pcut_realhdc2v1     pcut_goodHDC2v1 && ((P.dc.Ch1.spacepoints + P.dc.Ch2.spacepoints) > 0)
+pcut_realhdc2v2     pcut_goodHDC2v2 && ((P.dc.Ch1.spacepoints + P.dc.Ch2.spacepoints) > 0)
+pcut_realhdc2x2     pcut_goodHDC2x2 && ((P.dc.Ch1.spacepoints + P.dc.Ch2.spacepoints) > 0)
+
+pcut_Found1Track     P.dc.ntrack == 1
+pcut_Found2Track     P.dc.ntrack == 2
+pcut_Found3Track     P.dc.ntrack == 3
+pcut_Found4Track     P.dc.ntrack == 4
+
+pcut_CleanTrack      P.gtr.index > -1
+pcut_Clean1Track     P.gtr.index == 0
+pcut_Clean2Track     P.gtr.index == 1
+pcut_Clean3Track     P.gtr.index == 2
+pcut_Clean4Track     P.gtr.index == 3
+
+pcut_CleanTrack_cer_elec     (P.gtr.index > -1) && pcut_cer_elec_both
+pcut_p1hit1_cer_elec	     p1hit1 && pcut_cer_elec_both
+pcut_CleanTrack_cal_elec     (P.gtr.index > -1) && pcut_cal_elec
+pcut_p1hit1_cal_elec         p1hit1 && pcut_cal_elec
+
+pcut_anys1x     P.hod.1x.nhits > 0
+pcut_anys1y     P.hod.1y.nhits > 0
+pcut_anys2x     P.hod.2x.nhits > 0
+pcut_anys2y     P.hod.2y.nhits > 0
+
+pcut_goods1x      P.hod.1x.nhits > 0 && P.hod.1x.nhits < 3
+pcut_goods1y      P.hod.1y.nhits > 0 && P.hod.1y.nhits < 3
+pcut_goods1       pcut_goods1x && pcut_goods1y
+pcut_goods2x      P.hod.2x.nhits > 0 && P.hod.2x.nhits < 3
+pcut_goods2y      P.hod.2y.nhits > 0 && P.hod.2y.nhits < 3
+pcut_goods2       pcut_goods2x && pcut_goods2y
+pcut_goods1s2     pcut_goods1 && pcut_goods2
+
+SHMS_hgcer_track_matched_region_1 P.hgcer.numTracksMatched[0]>0
+SHMS_hgcer_track_fired_region_1 P.hgcer.numTracksFired[0]>0
+SHMS_hgcer_track_matched_region_2 P.hgcer.numTracksMatched[1]>0
+SHMS_hgcer_track_fired_region_2 P.hgcer.numTracksFired[1]>0
+SHMS_hgcer_track_matched_region_3 P.hgcer.numTracksMatched[2]>0
+SHMS_hgcer_track_fired_region_3 P.hgcer.numTracksFired[2]>0
+SHMS_hgcer_track_matched_region_4 P.hgcer.numTracksMatched[3]>0
+SHMS_hgcer_track_fired_region_4 P.hgcer.numTracksFired[3]>0
+SHMS_hgcer_track_matched_tot P.hgcer.totNumTracksMatched>0
+SHMS_hgcer_track_fired_tot P.hgcer.totNumTracksFired>0
+
+SHMS_ngcer_track_matched_region_1 P.ngcer.numTracksMatched[0]>0
+SHMS_ngcer_track_fired_region_1 P.ngcer.numTracksFired[0]>0
+SHMS_ngcer_track_matched_region_2 P.ngcer.numTracksMatched[1]>0
+SHMS_ngcer_track_fired_region_2 P.ngcer.numTracksFired[1]>0
+SHMS_ngcer_track_matched_region_3 P.ngcer.numTracksMatched[2]>0
+SHMS_ngcer_track_fired_region_3 P.ngcer.numTracksFired[2]>0
+SHMS_ngcer_track_matched_region_4 P.ngcer.numTracksMatched[3]>0
+SHMS_ngcer_track_fired_region_4 P.ngcer.numTracksFired[3]>0
+SHMS_ngcer_track_matched_tot P.ngcer.totNumTracksMatched>0
+SHMS_ngcer_track_fired_tot P.ngcer.totNumTracksFired>0
+
+SHMS_aero_track_matched_region_1 P.aero.numTracksMatched[0]>0
+SHMS_aero_track_fired_region_1 P.aero.numTracksFired[0]>0
+SHMS_aero_track_matched_region_2 P.aero.numTracksMatched[1]>0
+SHMS_aero_track_fired_region_2 P.aero.numTracksFired[1]>0
+SHMS_aero_track_matched_region_3 P.aero.numTracksMatched[2]>0
+SHMS_aero_track_fired_region_3 P.aero.numTracksFired[2]>0
+SHMS_aero_track_matched_region_4 P.aero.numTracksMatched[3]>0
+SHMS_aero_track_fired_region_4 P.aero.numTracksFired[3]>0
+SHMS_aero_track_matched_region_5 P.aero.numTracksMatched[4]>0
+SHMS_aero_track_fired_region_5 P.aero.numTracksFired[4]>0
+SHMS_aero_track_matched_region_6 P.aero.numTracksMatched[5]>0
+SHMS_aero_track_fired_region_6 P.aero.numTracksFired[5]>0
+SHMS_aero_track_matched_region_7 P.aero.numTracksMatched[6]>0
+SHMS_aero_track_fired_region_7 P.aero.numTracksFired[6]>0
+SHMS_aero_track_matched_tot P.aero.totNumTracksMatched>0
+SHMS_aero_track_fired_tot P.aero.totNumTracksFired>0

--- a/SCRIPTS/COIN/PRODUCTION/replay_production_coin_hElec_pProt.C
+++ b/SCRIPTS/COIN/PRODUCTION/replay_production_coin_hElec_pProt.C
@@ -75,9 +75,6 @@ void replay_production_coin_hElec_pProt (Int_t RunNumber = 0, Int_t MaxEvent = 0
   THcShower* pcal = new THcShower("cal", "Calorimeter");
   SHMS->AddDetector(pcal);
 
-  // Include golden track information
-  THaGoldenTrack* pgtr = new THaGoldenTrack("P.gtr", "SHMS Golden Track", "P");
-  gHaPhysics->Add(pgtr);
   // Add Rastered Beam Apparatus
   THaApparatus* pbeam = new THcRasteredBeam("P.rb", "SHMS Rastered Beamline");
   gHaApps->Add(pbeam);
@@ -85,6 +82,9 @@ void replay_production_coin_hElec_pProt (Int_t RunNumber = 0, Int_t MaxEvent = 0
   gHaPhysics->Add(prp);
   THcExtTarCor* pext = new THcExtTarCor("P.extcor"," HMS extended target corrections","P","P.react");
   gHaPhysics->Add(pext);
+  // Include golden track information
+  THaGoldenTrack* pgtr = new THaGoldenTrack("P.gtr", "SHMS Golden Track", "P");
+  gHaPhysics->Add(pgtr);
   // Add hodoscope efficiency
   THcHodoEff* peff = new THcHodoEff("phodeff"," SHMS hodo efficiency","P.hod");
   gHaPhysics->Add(peff);
@@ -129,9 +129,6 @@ void replay_production_coin_hElec_pProt (Int_t RunNumber = 0, Int_t MaxEvent = 0
   THcShower* hcal = new THcShower("cal", "Calorimeter");
   HMS->AddDetector(hcal);
 
-  // Include golden track information
-  THaGoldenTrack* hgtr = new THaGoldenTrack("H.gtr", "HMS Golden Track", "H");
-  gHaPhysics->Add(hgtr);
   // Add Rastered Beam Apparatus
   THaApparatus* hbeam = new THcRasteredBeam("H.rb", "HMS Rastered Beamline");
   gHaApps->Add(hbeam);
@@ -139,6 +136,9 @@ void replay_production_coin_hElec_pProt (Int_t RunNumber = 0, Int_t MaxEvent = 0
   gHaPhysics->Add(hrp);
   THcExtTarCor* hext = new THcExtTarCor("H.extcor"," HMS extended target corrections","H","H.react");
   gHaPhysics->Add(hext);
+  // Include golden track information
+  THaGoldenTrack* hgtr = new THaGoldenTrack("H.gtr", "HMS Golden Track", "H");
+  gHaPhysics->Add(hgtr);
   // Add hodoscope efficiency
   THcHodoEff* heff = new THcHodoEff("hhodeff"," HMS hodo efficiency","H.hod");
   gHaPhysics->Add(heff);

--- a/SCRIPTS/COIN/PRODUCTION/replay_production_coin_pElec_hProt.C
+++ b/SCRIPTS/COIN/PRODUCTION/replay_production_coin_pElec_hProt.C
@@ -75,9 +75,6 @@ void replay_production_coin_pElec_hProt (Int_t RunNumber = 0, Int_t MaxEvent = 0
   THcShower* pcal = new THcShower("cal", "Calorimeter");
   SHMS->AddDetector(pcal);
 
-  // Include golden track information
-  THaGoldenTrack* pgtr = new THaGoldenTrack("P.gtr", "SHMS Golden Track", "P");
-  gHaPhysics->Add(pgtr);
   // Add Rastered Beam Apparatus
   THaApparatus* pbeam = new THcRasteredBeam("P.rb", "SHMS Rastered Beamline");
   gHaApps->Add(pbeam);
@@ -85,7 +82,10 @@ void replay_production_coin_pElec_hProt (Int_t RunNumber = 0, Int_t MaxEvent = 0
   gHaPhysics->Add(prp);
   THcExtTarCor* pext = new THcExtTarCor("P.extcor"," HMS extended target corrections","P","P.react");
   gHaPhysics->Add(pext);
-  // Add hodoscope efficiency
+   // Include golden track information
+  THaGoldenTrack* pgtr = new THaGoldenTrack("P.gtr", "SHMS Golden Track", "P");
+  gHaPhysics->Add(pgtr);
+ // Add hodoscope efficiency
   THcHodoEff* peff = new THcHodoEff("phodeff"," SHMS hodo efficiency","P.hod");
   gHaPhysics->Add(peff);
 
@@ -129,9 +129,6 @@ void replay_production_coin_pElec_hProt (Int_t RunNumber = 0, Int_t MaxEvent = 0
   THcShower* hcal = new THcShower("cal", "Calorimeter");
   HMS->AddDetector(hcal);
 
-  // Include golden track information
-  THaGoldenTrack* hgtr = new THaGoldenTrack("H.gtr", "HMS Golden Track", "H");
-  gHaPhysics->Add(hgtr);
   // Add Rastered Beam Apparatus
   THaApparatus* hbeam = new THcRasteredBeam("H.rb", "HMS Rastered Beamline");
   gHaApps->Add(hbeam);
@@ -139,6 +136,9 @@ void replay_production_coin_pElec_hProt (Int_t RunNumber = 0, Int_t MaxEvent = 0
   gHaPhysics->Add(hrp);
   THcExtTarCor* hext = new THcExtTarCor("H.extcor"," HMS extended target corrections","H","H.react");
   gHaPhysics->Add(hext);
+  // Include golden track information
+  THaGoldenTrack* hgtr = new THaGoldenTrack("H.gtr", "HMS Golden Track", "H");
+  gHaPhysics->Add(hgtr);
   // Add hodoscope efficiency
   THcHodoEff* heff = new THcHodoEff("hhodeff"," HMS hodo efficiency","H.hod");
   gHaPhysics->Add(heff);

--- a/SCRIPTS/COIN/PRODUCTION/replay_production_ep.C
+++ b/SCRIPTS/COIN/PRODUCTION/replay_production_ep.C
@@ -75,9 +75,6 @@ void replay_production_ep (Int_t RunNumber = 0, Int_t MaxEvent = 0) {
   THcShower* pcal = new THcShower("cal", "Calorimeter");
   SHMS->AddDetector(pcal);
 
-  // Include golden track information
-  THaGoldenTrack* pgtr = new THaGoldenTrack("P.gtr", "SHMS Golden Track", "P");
-  gHaPhysics->Add(pgtr);
   // Add Rastered Beam Apparatus
   THaApparatus* pbeam = new THcRasteredBeam("P.rb", "SHMS Rastered Beamline");
   gHaApps->Add(pbeam);
@@ -85,6 +82,9 @@ void replay_production_ep (Int_t RunNumber = 0, Int_t MaxEvent = 0) {
   gHaPhysics->Add(prp);
   THcExtTarCor* pext = new THcExtTarCor("P.extcor"," HMS extended target corrections","P","P.react");
   gHaPhysics->Add(pext);
+  // Include golden track information
+  THaGoldenTrack* pgtr = new THaGoldenTrack("P.gtr", "SHMS Golden Track", "P");
+  gHaPhysics->Add(pgtr);
 
 
   // Hodoscope efficiency
@@ -130,17 +130,17 @@ void replay_production_ep (Int_t RunNumber = 0, Int_t MaxEvent = 0) {
   THcShower* hcal = new THcShower("cal", "Calorimeter");
   HMS->AddDetector(hcal);
 
-  // Include golden track information
-  THaGoldenTrack* hgtr = new THaGoldenTrack("H.gtr", "HMS Golden Track", "H");
-  gHaPhysics->Add(hgtr);
-  // Add Rastered Beam Apparatus
+ // Add Rastered Beam Apparatus
   THaApparatus* hbeam = new THcRasteredBeam("H.rb", "HMS Rastered Beamline");
   gHaApps->Add(hbeam);
   THaReactionPoint* hrp= new THaReactionPoint("H.react"," HMS reaction point","H","H.rb");
   gHaPhysics->Add(hrp);
   THcExtTarCor* hext = new THcExtTarCor("H.extcor"," HMS extended target corrections","H","H.react");
   gHaPhysics->Add(hext);
-  // Hodoscope efficiency
+  // Include golden track information
+  THaGoldenTrack* hgtr = new THaGoldenTrack("H.gtr", "HMS Golden Track", "H");
+  gHaPhysics->Add(hgtr);
+   // Hodoscope efficiency
   THcHodoEff* heff = new THcHodoEff("hhodeff"," HMS hodo efficiency","H.hod");
   gHaPhysics->Add(heff);
   // Add event handler for scaler events

--- a/SCRIPTS/HMS/PRODUCTION/replay_production_all_hms.C
+++ b/SCRIPTS/HMS/PRODUCTION/replay_production_all_hms.C
@@ -69,16 +69,16 @@ void replay_production_all_hms(Int_t RunNumber=0, Int_t MaxEvent=0) {
   THcShower* cal = new THcShower("cal", "Calorimeter");
   HMS->AddDetector(cal);
 
-  // Include golden track information
-  THaGoldenTrack* gtr = new THaGoldenTrack("H.gtr", "HMS Golden Track", "H");
-  gHaPhysics->Add(gtr);
-  // Add Rastered Beam Apparatus
+   // Add Rastered Beam Apparatus
   THaApparatus* beam = new THcRasteredBeam("H.rb", "Rastered Beamline");
   gHaApps->Add(beam);  
   THaReactionPoint* hrp= new THaReactionPoint("H.react", "HMS reaction point", "H", "H.rb");
   gHaPhysics->Add(hrp);
   THcExtTarCor* hext = new THcExtTarCor("H.extcor", "HMS extended target corrections", "H", "H.react");
   gHaPhysics->Add(hext);
+ // Include golden track information
+  THaGoldenTrack* gtr = new THaGoldenTrack("H.gtr", "HMS Golden Track", "H");
+  gHaPhysics->Add(gtr);
   // Add Ideal Beam Apparatus
   // THaApparatus* beam = new THaIdealBeam("IB", "Ideal Beamline");
   // gHaApps->Add(beam);

--- a/SCRIPTS/HMS/PRODUCTION/replay_production_hms.C
+++ b/SCRIPTS/HMS/PRODUCTION/replay_production_hms.C
@@ -69,9 +69,6 @@ void replay_production_hms(Int_t RunNumber=0, Int_t MaxEvent=0) {
   THcShower* cal = new THcShower("cal", "Calorimeter");
   HMS->AddDetector(cal);
 
-  // Include golden track information
-  THaGoldenTrack* gtr = new THaGoldenTrack("H.gtr", "HMS Golden Track", "H");
-  gHaPhysics->Add(gtr);
 // Add Rastered Beam Apparatus
   THaApparatus* beam = new THcRasteredBeam("H.rb", "Rastered Beamline");
   gHaApps->Add(beam);  
@@ -79,6 +76,9 @@ void replay_production_hms(Int_t RunNumber=0, Int_t MaxEvent=0) {
   gHaPhysics->Add(hrp);
   THcExtTarCor* hext = new THcExtTarCor("H.extcor"," HMS extended target corrections","H","H.react");
   gHaPhysics->Add(hext);
+  // Include golden track information
+  THaGoldenTrack* gtr = new THaGoldenTrack("H.gtr", "HMS Golden Track", "H");
+  gHaPhysics->Add(gtr);
 // Add Ideal Beam Apparatus
  // THaApparatus* beam = new THaIdealBeam("IB", "Ideal Beamline");
  // gHaApps->Add(beam);

--- a/SCRIPTS/HMS/PRODUCTION/replay_production_hms_coin.C
+++ b/SCRIPTS/HMS/PRODUCTION/replay_production_hms_coin.C
@@ -75,9 +75,6 @@ void replay_production_hms_coin(Int_t RunNumber=0, Int_t MaxEvent=0) {
   hms->SetSpectName("H");
   TRG->AddDetector(hms);
 
-  // Include golden track information
-  THaGoldenTrack* gtr = new THaGoldenTrack("H.gtr", "HMS Golden Track", "H");
-  gHaPhysics->Add(gtr);
 // Add Rastered Beam Apparatus
   THaApparatus* beam = new THcRasteredBeam("H.rb", "Rastered Beamline");
   gHaApps->Add(beam);  
@@ -85,6 +82,9 @@ void replay_production_hms_coin(Int_t RunNumber=0, Int_t MaxEvent=0) {
   gHaPhysics->Add(hrp);
   THcExtTarCor* hext = new THcExtTarCor("H.extcor"," HMS extended target corrections","H","H.react");
   gHaPhysics->Add(hext);
+  // Include golden track information
+  THaGoldenTrack* gtr = new THaGoldenTrack("H.gtr", "HMS Golden Track", "H");
+  gHaPhysics->Add(gtr);
 // Add Ideal Beam Apparatus
  // THaApparatus* beam = new THaIdealBeam("IB", "Ideal Beamline");
  // gHaApps->Add(beam);

--- a/SCRIPTS/SHMS/PRODUCTION/replay_production_all_shms.C
+++ b/SCRIPTS/SHMS/PRODUCTION/replay_production_all_shms.C
@@ -73,9 +73,6 @@ void replay_production_all_shms (Int_t RunNumber = 0, Int_t MaxEvent = 0) {
   THcShower* cal = new THcShower("cal", "Calorimeter");
   SHMS->AddDetector(cal);
 
-  // Include golden track information
-  THaGoldenTrack* gtr = new THaGoldenTrack("P.gtr", "SHMS Golden Track", "P");
-  gHaPhysics->Add(gtr);
   // Add Rastered Beam Apparatus
   THaApparatus* beam = new THcRasteredBeam("P.rb", "Rastered Beamline");
   gHaApps->Add(beam);
@@ -83,6 +80,9 @@ void replay_production_all_shms (Int_t RunNumber = 0, Int_t MaxEvent = 0) {
   gHaPhysics->Add(prp);
   THcExtTarCor* pext = new THcExtTarCor("P.extcor", "HMS extended target corrections", "P", "P.react");
   gHaPhysics->Add(pext);
+  // Include golden track information
+  THaGoldenTrack* gtr = new THaGoldenTrack("P.gtr", "SHMS Golden Track", "P");
+  gHaPhysics->Add(gtr);
   // Add Physics Module to calculate primary (scattered beam - usually electrons) kinematics
   THcPrimaryKine* kin = new THcPrimaryKine("P.kin", "SHMS Single Arm Kinematics", "P", "P.rb");
   gHaPhysics->Add(kin);

--- a/SCRIPTS/SHMS/PRODUCTION/replay_production_shms.C
+++ b/SCRIPTS/SHMS/PRODUCTION/replay_production_shms.C
@@ -75,9 +75,6 @@ void replay_production_shms (Int_t RunNumber = 0, Int_t MaxEvent = 0) {
   THcShower* cal = new THcShower("cal", "Calorimeter");
   SHMS->AddDetector(cal);
 
-  // Include golden track information
-  THaGoldenTrack* gtr = new THaGoldenTrack("P.gtr", "SHMS Golden Track", "P");
-  gHaPhysics->Add(gtr);
   // Add Rastered Beam Apparatus
   THaApparatus* beam = new THcRasteredBeam("P.rb", "Rastered Beamline");
   gHaApps->Add(beam);
@@ -85,6 +82,9 @@ void replay_production_shms (Int_t RunNumber = 0, Int_t MaxEvent = 0) {
   gHaPhysics->Add(prp);
   THcExtTarCor* pext = new THcExtTarCor("P.extcor"," HMS extended target corrections","P","P.react");
   gHaPhysics->Add(pext);
+  // Include golden track information
+  THaGoldenTrack* gtr = new THaGoldenTrack("P.gtr", "SHMS Golden Track", "P");
+  gHaPhysics->Add(gtr);
   // Add Physics Module to calculate primary (scattered beam - usually electrons) kinematics
   THcPrimaryKine* kin = new THcPrimaryKine("P.kin", "SHMS Single Arm Kinematics", "P", "P.rb");
   gHaPhysics->Add(kin);

--- a/SCRIPTS/SHMS/PRODUCTION/replay_production_shms_coin.C
+++ b/SCRIPTS/SHMS/PRODUCTION/replay_production_shms_coin.C
@@ -80,9 +80,6 @@ void replay_production_shms_coin (Int_t RunNumber = 0, Int_t MaxEvent = 0) {
   shms->SetSpectName("P");
   TRG->AddDetector(shms);
 
-  // Include golden track information
-  THaGoldenTrack* gtr = new THaGoldenTrack("P.gtr", "SHMS Golden Track", "P");
-  gHaPhysics->Add(gtr);
   // Add Rastered Beam Apparatus
   THaApparatus* beam = new THcRasteredBeam("P.rb", "Rastered Beamline");
   gHaApps->Add(beam);
@@ -90,6 +87,9 @@ void replay_production_shms_coin (Int_t RunNumber = 0, Int_t MaxEvent = 0) {
   gHaPhysics->Add(prp);
   THcExtTarCor* pext = new THcExtTarCor("P.extcor"," HMS extended target corrections","P","P.react");
   gHaPhysics->Add(pext);
+  // Include golden track information
+  THaGoldenTrack* gtr = new THaGoldenTrack("P.gtr", "SHMS Golden Track", "P");
+  gHaPhysics->Add(gtr);
   // Add Physics Module to calculate primary (scattered beam - usually electrons) kinematics
   THcPrimaryKine* kin = new THcPrimaryKine("P.kin", "SHMS Single Arm Kinematics", "P", "P.rb");
   gHaPhysics->Add(kin);


### PR DESCRIPTION
Modify PRODUCTION scripts

Move the Goldentrack to go after the ExtTarCor,
since ExtTarCor modifies the target quantities.

Modified DEF-files/COIN/PRODUCTION/coin_production_hElec_pProt_cuts.def

made new files for HMS/SHMS Coarsetracking and reconstruction
sections that were cut out of the hstackana and pstackana.
Then include them separately.
