### PR TITLE
Updates to DEF-files and onlineGUI for HMS DC wire efficiency

### DIFF
--- a/DEF-files/HMS/PRODUCTION/DC/hdc_eff_histos.def
+++ b/DEF-files/HMS/PRODUCTION/DC/hdc_eff_histos.def
@@ -1,0 +1,41 @@
+#**********************
+# HMS Drift Chambers  *
+#**********************
+
+#------------------
+# HMS DC WIRE MAP for per wire efficiency
+#   first set with "should" cut
+#-----------------
+
+TH1F hdc1u1_wirenum_should 'HMS DC 1U1 Wiremap; Wire Number; Number of Entries'  H.dc.wireHitShould[0] 96 0.5 96.5  
+TH1F hdc1u2_wirenum_should 'HMS DC 1U2 Wiremap; Wire Number; Number of Entries' H.dc.wireHitShould[1] 96 0.5 96.5  
+TH1F hdc1x1_wirenum_should 'HMS DC 1X1 Wiremap; Wire Number; Number of Entries' H.dc.wireHitShould[2]  102 0.5  102.5
+TH1F hdc1x2_wirenum_should 'HMS DC 1X2 Wiremap; Wire Number; Number of Entries' H.dc.wireHitShould[3]  102 0.5  102.5 
+TH1F hdc1v1_wirenum_should 'HMS DC 1V1 Wiremap; Wire Number; Number of Entries'  H.dc.wireHitShould[4] 96 0.5 96.5 
+TH1F hdc1v2_wirenum_should 'HMS DC 1V2 Wiremap; Wire Number; Number of Entries' H.dc.wireHitShould[5] 96 0.5 96.5 
+
+TH1F hdc2v2_wirenum_should 'HMS DC 2V2 Wiremap; Wire Number; Number of Entries' H.dc.wireHitShould[6] 96 0.5 96.5 
+TH1F hdc2v1_wirenum_should 'HMS DC 2V1 Wiremap; Wire Number; Number of Entries' H.dc.wireHitShould[7] 96 0.5 96.5 
+TH1F hdc2x2_wirenum_should 'HMS DC 2X2 Wiremap; Wire Number; Number of Entries' H.dc.wireHitShould[8]  102 0.5  102.5 
+TH1F hdc2x1_wirenum_should 'HMS DC 2X1 Wiremap; Wire Number; Number of Entries' H.dc.wireHitShould[9]  102 0.5  102.5 
+TH1F hdc2u2_wirenum_should 'HMS DC 2U2 Wiremap; Wire Number; Number of Entries' H.dc.wireHitShould[10] 96 0.5 96.5 
+TH1F hdc2u1_wirenum_should 'HMS DC 2U1 Wiremap; Wire Number; Number of Entries' H.dc.wireHitShould[11] 96 0.5 96.5 
+#------------------
+# HMS DC WIRE MAP for per wire efficiency
+#   first set with "did" cut
+#-----------------
+
+TH1F hdc1u1_wirenum_did 'HMS DC 1U1 Wiremap; Wire Number; Number of Entries'  H.dc.wireHitDid[0] 96 0.5 96.5  
+TH1F hdc1u2_wirenum_did 'HMS DC 1U2 Wiremap; Wire Number; Number of Entries' H.dc.wireHitDid[1] 96 0.5 96.5  
+TH1F hdc1x1_wirenum_did 'HMS DC 1X1 Wiremap; Wire Number; Number of Entries' H.dc.wireHitDid[2]  102 0.5  102.5
+TH1F hdc1x2_wirenum_did 'HMS DC 1X2 Wiremap; Wire Number; Number of Entries' H.dc.wireHitDid[3]  102 0.5  102.5 
+TH1F hdc1v1_wirenum_did 'HMS DC 1V1 Wiremap; Wire Number; Number of Entries'  H.dc.wireHitDid[4] 96 0.5 96.5 
+TH1F hdc1v2_wirenum_did 'HMS DC 1V2 Wiremap; Wire Number; Number of Entries' H.dc.wireHitDid[5] 96 0.5 96.5 
+
+TH1F hdc2v2_wirenum_did 'HMS DC 2V2 Wiremap; Wire Number; Number of Entries' H.dc.wireHitDid[6] 96 0.5 96.5 
+TH1F hdc2v1_wirenum_did 'HMS DC 2V1 Wiremap; Wire Number; Number of Entries' H.dc.wireHitDid[7] 96 0.5 96.5 
+TH1F hdc2x2_wirenum_did 'HMS DC 2X2 Wiremap; Wire Number; Number of Entries' H.dc.wireHitDid[8]  102 0.5  102.5 
+TH1F hdc2x1_wirenum_did 'HMS DC 2X1 Wiremap; Wire Number; Number of Entries' H.dc.wireHitDid[9]  102 0.5  102.5 
+TH1F hdc2u2_wirenum_did 'HMS DC 2U2 Wiremap; Wire Number; Number of Entries' H.dc.wireHitDid[10] 96 0.5 96.5 
+TH1F hdc2u1_wirenum_did 'HMS DC 2U1 Wiremap; Wire Number; Number of Entries' H.dc.wireHitDid[11] 96 0.5 96.5 
+

--- a/DEF-files/HMS/PRODUCTION/hstackana_production.def
+++ b/DEF-files/HMS/PRODUCTION/hstackana_production.def
@@ -1,6 +1,8 @@
 #include "DEF-files/HMS/PRODUCTION/CAL/hcal_histos.def"
 #include "DEF-files/HMS/PRODUCTION/CER/hcer_histos.def"
 #include "DEF-files/HMS/PRODUCTION/DC/hdc_histos.def"
+#include "DEF-files/HMS/TEST_STANDS/DC/hdc_resid.def"
+#include "DEF-files/HMS/PRODUCTION/DC/hdc_eff_histos.def"
 #include "DEF-files/HMS/PRODUCTION/HODO/hhodo_histos.def"
 #include "DEF-files/HMS/PRODUCTION/KIN/hkin_histos.def"
 #include "DEF-files/HMS/PRODUCTION/GTR/hgtr_histos.def"

--- a/DEF-files/HMS/TEST_STANDS/DC/hdc_resid.def
+++ b/DEF-files/HMS/TEST_STANDS/DC/hdc_resid.def
@@ -1,0 +1,35 @@
+#-----------------------------
+# HMS DC RESIDUALS PER PLANE 
+#-----------------------------
+
+TH1F hdc1u1_residuals 'HMS 1U1 DC Residuals; Residuals (cm); Number of Entries / 0.01 cm' H.dc.residual[0]  200 -1.0 1.0
+TH1F hdc1u2_residuals 'HMS 1U2 DC Residuals; Residuals (cm); Number of Entries / 0.01 cm' H.dc.residual[1]  200 -1.0 1.0
+TH1F hdc1x1_residuals 'HMS 1X1 DC Residuals; Residuals (cm); Number of Entries / 0.01 cm' H.dc.residual[2]  200 -1.0 1.0
+TH1F hdc1x2_residuals 'HMS 1X2 DC Residuals; Residuals (cm); Number of Entries / 0.01 cm' H.dc.residual[3]  200 -1.0 1.0
+TH1F hdc1v1_residuals 'HMS 1V1 DC Residuals; Residuals (cm); Number of Entries / 0.01 cm' H.dc.residual[4]  200 -1.0 1.0
+TH1F hdc1v2_residuals 'HMS 1V2 DC Residuals; Residuals (cm); Number of Entries / 0.01 cm' H.dc.residual[5]  200 -1.0 1.0
+
+TH1F hdc2v2_residuals 'HMS 2V2 DC Residuals; Residuals (cm); Number of Entries / 0.01 cm' H.dc.residual[6]  200 -1.0 1.0
+TH1F hdc2v1_residuals 'HMS 2V1 DC Residuals; Residuals (cm); Number of Entries / 0.01 cm' H.dc.residual[7]  200 -1.0 1.0
+TH1F hdc2x2_residuals 'HMS 2X2 DC Residuals; Residuals (cm); Number of Entries / 0.01 cm' H.dc.residual[8]  200 -1.0 1.0
+TH1F hdc2x1_residuals 'HMS 2X1 DC Residuals; Residuals (cm); Number of Entries / 0.01 cm' H.dc.residual[9]  200 -1.0 1.0
+TH1F hdc2u2_residuals 'HMS 2U2 DC Residuals; Residuals (cm); Number of Entries / 0.01 cm' H.dc.residual[10] 200 -1.0 1.0
+TH1F hdc2u1_residuals 'HMS 2U1 DC Residuals; Residuals (cm); Number of Entries / 0.01 cm' H.dc.residual[11] 200 -1.0 1.0
+
+#-----------------------------------
+# HMS DC RESIDUALS vs. Wire Number
+#-----------------------------------
+
+TH2F hdc1u1_residuals_vs_wirenum 'HMS 1U1 DC Residuals vs. Wire Number; Wire Number; Residuals (cm)' H.dc.1u1.wirenum H.dc.residual[0] 96 0.5 96.5 200 -1.0 1.0
+TH2F hdc1u2_residuals_vs_wirenum 'HMS 1U2 DC Residuals vs. Wire Number; Wire Number; Residuals (cm)' H.dc.1u2.wirenum H.dc.residual[1] 96 0.5 96.5 200 -1.0 1.0
+TH2F hdc1x1_residuals_vs_wirenum 'HMS 1X1 DC Residuals vs. Wire Number; Wire Number; Residuals (cm)' H.dc.1x1.wirenum H.dc.residual[2] 102 0.5  102.5 200 -1.0 1.0
+TH2F hdc1x2_residuals_vs_wirenum 'HMS 1X2 DC Residuals vs. Wire Number; Wire Number; Residuals (cm)' H.dc.1x2.wirenum H.dc.residual[3] 102 0.5  102.5 200 -1.0 1.0
+TH2F hdc1v1_residuals_vs_wirenum 'HMS 1V1 DC Residuals vs. Wire Number; Wire Number; Residuals (cm)' H.dc.1v1.wirenum H.dc.residual[4] 96 0.5 96.5 200 -1.0 1.0
+TH2F hdc1v2_residuals_vs_wirenum 'HMS 1V2 DC Residuals vs. Wire Number; Wire Number; Residuals (cm)' H.dc.1v2.wirenum H.dc.residual[5] 96 0.5 96.5 200 -1.0 1.0
+
+TH2F hdc2v2_residuals_vs_wirenum 'HMS 2V2 DC Residuals vs. Wire Number; Wire Number; Residuals (cm)' H.dc.2v2.wirenum H.dc.residual[6] 96 0.5 96.5 200 -1.0 1.0
+TH2F hdc2v1_residuals_vs_wirenum 'HMS 2V1 DC Residuals vs. Wire Number; Wire Number; Residuals (cm)' H.dc.2v1.wirenum H.dc.residual[7] 96 0.5 96.5 200 -1.0 1.0
+TH2F hdc2x2_residuals_vs_wirenum 'HMS 2X2 DC Residuals vs. Wire Number; Wire Number; Residuals (cm)' H.dc.2x2.wirenum H.dc.residual[8] 102 0.5  102.5 200 -1.0 1.0
+TH2F hdc2x1_residuals_vs_wirenum 'HMS 2X1 DC Residuals vs. Wire Number; Wire Number; Residuals (cm)' H.dc.2x1.wirenum H.dc.residual[9] 102 0.5  102.5 200 -1.0 1.0
+TH2F hdc2u2_residuals_vs_wirenum 'HMS 2U2 DC Residuals vs. Wire Number; Wire Number; Residuals (cm)' H.dc.2u2.wirenum H.dc.residual[10] 96 0.5 96.5 200 -1.0 1.0
+TH2F hdc2u1_residuals_vs_wirenum 'HMS 2U1 DC Residuals vs. Wire Number; Wire Number; Residuals (cm)' H.dc.2u1.wirenum H.dc.residual[11] 96 0.5 96.5 200 -1.0 1.0

--- a/onlineGUI/CONFIG/HMS/TEST_STANDS/DC/hdc_wireeff.cfg
+++ b/onlineGUI/CONFIG/HMS/TEST_STANDS/DC/hdc_wireeff.cfg
@@ -1,0 +1,35 @@
+protorootfile ../ROOTfiles/hms_replay_production_XXXXX_100000.root
+guicolor lightblue
+canvassize 800 800
+newpage 2 3
+title HMS DC1 
+macro UTIL/GEN/overlay2.C("hdc1x1_wirenum_did","hdc1x1_wirenum_should","did","should")
+macro UTIL/GEN/overlay2.C("hdc1x2_wirenum_did","hdc1x2_wirenum_should","did","should")
+macro UTIL/GEN/overlay2.C("hdc1u1_wirenum_did","hdc1u1_wirenum_should","did","should")
+macro UTIL/GEN/overlay2.C("hdc1u2_wirenum_did","hdc1u2_wirenum_should","did","should")
+macro UTIL/GEN/overlay2.C("hdc1v1_wirenum_did","hdc1v1_wirenum_should","did","should")
+macro UTIL/GEN/overlay2.C("hdc1v2_wirenum_did","hdc1v2_wirenum_should","did","should")
+newpage 2 3
+title HMS DC1 eff
+macro UTIL/GEN/dcwire_efficiency.C("hdc1x1_wirenum_did","hdc1x1_wirenum_should")
+macro UTIL/GEN/dcwire_efficiency.C("hdc1x2_wirenum_did","hdc1x2_wirenum_should")
+macro UTIL/GEN/dcwire_efficiency.C("hdc1u1_wirenum_did","hdc1u1_wirenum_should")
+macro UTIL/GEN/dcwire_efficiency.C("hdc1u2_wirenum_did","hdc1u2_wirenum_should")
+macro UTIL/GEN/dcwire_efficiency.C("hdc1v1_wirenum_did","hdc1v1_wirenum_should")
+macro UTIL/GEN/dcwire_efficiency.C("hdc1v2_wirenum_did","hdc1v2_wirenum_should")
+newpage 2 3
+title HMS DC2
+macro UTIL/GEN/overlay2.C("hdc2x1_wirenum_did","hdc2x1_wirenum_should","did","should")
+macro UTIL/GEN/overlay2.C("hdc2x2_wirenum_did","hdc2x2_wirenum_should","did","should")
+macro UTIL/GEN/overlay2.C("hdc2u1_wirenum_did","hdc2u1_wirenum_should","did","should")
+macro UTIL/GEN/overlay2.C("hdc2u2_wirenum_did","hdc2u2_wirenum_should","did","should")
+macro UTIL/GEN/overlay2.C("hdc2v1_wirenum_did","hdc2v1_wirenum_should","did","should")
+macro UTIL/GEN/overlay2.C("hdc2v2_wirenum_did","hdc2v2_wirenum_should","did","should")
+newpage 2 3
+title HMS DC2 eff
+macro UTIL/GEN/dcwire_efficiency.C("hdc2x1_wirenum_did","hdc2x1_wirenum_should")
+macro UTIL/GEN/dcwire_efficiency.C("hdc2x2_wirenum_did","hdc2x2_wirenum_should")
+macro UTIL/GEN/dcwire_efficiency.C("hdc2u1_wirenum_did","hdc2u1_wirenum_should")
+macro UTIL/GEN/dcwire_efficiency.C("hdc2u2_wirenum_did","hdc2u2_wirenum_should")
+macro UTIL/GEN/dcwire_efficiency.C("hdc2v1_wirenum_did","hdc2v1_wirenum_should")
+macro UTIL/GEN/dcwire_efficiency.C("hdc2v2_wirenum_did","hdc2v2_wirenum_should")

--- a/onlineGUI/UTIL/GEN/dcwire_efficiency.C
+++ b/onlineGUI/UTIL/GEN/dcwire_efficiency.C
@@ -1,0 +1,24 @@
+void dcwire_efficiency(TString hist1name, TString hist2name){
+  TH1F* H1;
+  TH1F* H2;
+  
+  H1 = (TH1F*) gDirectory->Get(hist1name);
+  H2 = (TH1F*) gDirectory->Get(hist2name);
+  if (H1 && H2) {
+    H1->Sumw2();
+    H2->Sumw2();
+    TH1F* Hratio=(TH1F*)H1->Clone();
+    Hratio->Divide(H1,H2,1,1,"B");
+    Hratio->SetStats(0);
+    Hratio->SetMinimum(0.0);
+    Hratio->SetMaximum(1.05);
+    Hratio->Draw("EP");
+    Hratio->GetXaxis()->SetTitleOffset(.6);
+    Hratio->GetXaxis()->SetTitleSize(0.08);
+    Hratio->GetYaxis()->SetTitleOffset(.6);
+    Hratio->GetYaxis()->SetTitleSize(0.08);
+  } else {
+    if (!H1) cout << " Histogram " << hist1name << " does not exist" << endl;
+    if (!H2) cout << " Histogram " << hist2name << " does not exist" << endl;
+  }
+}


### PR DESCRIPTION
In THcDC.cxx the method EfficiencyPerWire is called
which for the Golden track calculates which wire in each plane
"should" have been hit ( fills wirenumber in H.dc.wireHitShould[planenum]
and also calculates which wire "did" get hit by the track ( fills
wirenumber in H.dc.wireHitDid[planenum]) .

As an example of HMS histograms was created in
DEF-files/HMS/PRODUCTION/DC/hdc_eff_histos.def
which creates two sets of histograms for each plane
of the "should" and "did" wire numbers.

Updated hstackana_production.def to include
hdc_eff_histos.def and a newly created TEST_STANDS/DC/hdc_resid.def

For onlineGUI create UTIL/GEN/dcwire_efficiency.C for taking
ratio of the "did" and "should" histograms
and as exmaple HMS/TEST_STANDS/DC/hdc_wireeff.cfg for plotting
the histograms.