### PR TITLE
Reference time cuts and SHMS tracking parameter updates

### DIFF
--- a/DBASE/COIN/general.param
+++ b/DBASE/COIN/general.param
@@ -16,6 +16,7 @@ cminch=2.54
 #include "PARAM/HMS/GEN/hdebug.param"
 #include "PARAM/HMS/GEN/hmsflags.param"
 #include "PARAM/HMS/GEN/htracking.param"
+#include "PARAM/HMS/GEN/h_reftime_cut.param"
 
 ; HMS default geometry parameter files 
 #include "PARAM/HMS/CER/hcer_geom.param"
@@ -45,6 +46,7 @@ cminch=2.54
 #include "PARAM/SHMS/GEN/pdebug.param"
 #include "PARAM/SHMS/GEN/shmsflags.param"
 #include "PARAM/SHMS/GEN/ptracking.param"
+#include "PARAM/SHMS/GEN/p_reftime_cut.param"
 
 ; SHMS default geometry parameter files
 #include "PARAM/SHMS/NGCER/pngcer_geom.param"

--- a/DBASE/HMS/general.param
+++ b/DBASE/HMS/general.param
@@ -16,6 +16,7 @@ cminch=2.54
 #include "PARAM/HMS/GEN/hdebug.param"
 #include "PARAM/HMS/GEN/hmsflags.param"
 #include "PARAM/HMS/GEN/htracking.param"
+#include "PARAM/HMS/GEN/h_reftime_cut.param"
 
 ; HMS default geometry parameter files 
 #include "PARAM/HMS/CER/hcer_geom.param"

--- a/DBASE/SHMS/general.param
+++ b/DBASE/SHMS/general.param
@@ -16,6 +16,7 @@ cminch=2.54
 #include "PARAM/SHMS/GEN/pdebug.param"
 #include "PARAM/SHMS/GEN/shmsflags.param"
 #include "PARAM/SHMS/GEN/ptracking.param"
+#include "PARAM/SHMS/GEN/p_reftime_cut.param"
 
 ; SHMS default geometry parameter files
 #include "PARAM/SHMS/NGCER/pngcer_geom.param"

--- a/PARAM/HMS/GEN/h_reftime_cut.param
+++ b/PARAM/HMS/GEN/h_reftime_cut.param
@@ -1,0 +1,16 @@
+; Cut to select the Reference time when multiple hits in reference time 
+; The units in channels for the module (CAEN tdc or FADC)
+; negative value refcut means that the first reference time greater than the abs(refcut)
+;     is used as reftime. If no ref time is found  greater than the abs(refcut) then first
+;     reference time is used.
+; positive value refcut means that the the first reference time greater than the abs(refcut)
+;     is used as reftime. If no ref time is found  greater than the abs(refcut) then no
+;     reference time is used and warning message is produced.
+; Cut is on reference time per detector.
+hdc_tdcrefcut=-14000.
+hhodo_tdcrefcut=-2000.
+hhodo_adcrefcut=-150./.0625
+hcer_adcrefcut=-150./.0625
+hcal_adcrefcut=-150./.0625
+
+

--- a/PARAM/SHMS/GEN/p_reftime_cut.param
+++ b/PARAM/SHMS/GEN/p_reftime_cut.param
@@ -1,0 +1,18 @@
+; Cut to select the Reference time when multiple hits in reference time 
+; The units in channels for the module (CAEN tdc or FADC)
+; negative value refcut means that the first reference time greater than the abs(refcut)
+;     is used as reftime. If no ref time is found  greater than the abs(refcut) then first
+;     reference time is used.
+; positive value refcut means that the the first reference time greater than the abs(refcut)
+;     is used as reftime. If no ref time is found  greater than the abs(refcut) then no
+;     reference time is used and warning message is produced.
+; Cut is on reference time per detector.
+pdc_tdcrefcut=-14000.
+phodo_tdcrefcut=-3000.
+phodo_adcrefcut=-200./.0625
+pngcer_adcrefcut=-200./.0625
+phgcer_adcrefcut=-200./.0625
+paero_adcrefcut=-200./.0625
+pcal_adcrefcut=-200./.0625
+
+

--- a/PARAM/SHMS/GEN/ptracking.param
+++ b/PARAM/SHMS/GEN/ptracking.param
@@ -84,9 +84,9 @@ pntracks_max_fp = 10
 ;Derek added this for scintillator based fiducial cuts.  Everything from
 ;loscin to hiscin inclusive will be included as "good" scintillator hits.
   pxloscin  = 4, 4
-  pxhiscin  = 13, 13
-  pyloscin  = 4, 4
-  pyhiscin  = 7, 7
+  pxhiscin  = 11, 10
+  pyloscin  = 4, 6
+  pyhiscin  = 11, 14
 ;  ptrack_eff_test_scin_planes is the number of planes nec needed to
 ;  set sweet spot to true. 4 is extra clean, 3 is good enough for e-'s.
-  ptrack_eff_test_num_scin_planes = 4
+  ptrack_eff_test_num_scin_planes = 3


### PR DESCRIPTION
Add reference time cuts PARAMETERS for SHMS/HMS

Add file PARAM/SHMS/GEN/p_reftime_cut.param

Add file PARAM/HMS/GEN/h_reftime_cut.param

Update the COIN/SHMS/HMS general.param in DBASE
to use these files.

Update PARAM/SHMS/GEN/ptracking.param

Updated pxloscin,pxhiscin,pyloscin and pyhiscin for
the track efficiency tests.