### PR TITLE
Update HMS/SHMS Cerenkov adcTimeWindow parameters

### DIFF
--- a/PARAM/HMS/CER/hcer_cuts.param
+++ b/PARAM/HMS/CER/hcer_cuts.param
@@ -18,8 +18,8 @@ hcer_dp_max = 25.0
 
 hcer_adc_tdc_window= 200.
 ; ADC time window cut values used to select "good" ADC events
-hcer_adcTimeWindowMin = -1000.
-hcer_adcTimeWindowMax = 1000.
+hcer_adcTimeWindowMin = -1000.,-1000.
+hcer_adcTimeWindowMax = 1000.,1000.
 
 ; NPE Threshold for good hit (for measureing effic.)
 hcer_npe_thresh = 0.5

--- a/PARAM/SHMS/HGCER/phgcer_cuts.param
+++ b/PARAM/SHMS/HGCER/phgcer_cuts.param
@@ -16,8 +16,8 @@ phgcer_dp_max = 25.0
 
 ; ADC time window cut values used to select "good" ADC events
 phgcer_adc_tdc_offset = 200.0
-phgcer_adcTimeWindowMin = -1000.
-phgcer_adcTimeWindowMax = 1000.
+phgcer_adcTimeWindowMin = -1000.,-1000.,-1000.,-1000.
+phgcer_adcTimeWindowMax = 1000.,1000.,1000.,1000.
 
 ; NPE Threshold for "good" hit (for measureing effic.)
 phgcer_npe_thresh = 0.5

--- a/PARAM/SHMS/NGCER/pngcer_cuts.param
+++ b/PARAM/SHMS/NGCER/pngcer_cuts.param
@@ -16,8 +16,8 @@ pngcer_dp_max = 25.0
 
 ; ADC time window cut values used to select "good" ADC events
 pngcer_adc_tdc_offset = 200.
-pngcer_adcTimeWindowMin = -1000.
-pngcer_adcTimeWindowMax = 1000.
+pngcer_adcTimeWindowMin = -1000.,-1000.,-1000.,-1000.
+pngcer_adcTimeWindowMax = 1000.,1000.,1000.,1000.
 
 ; ; NPE Threshold for "good" hit (for measureing effic.)
 pngcer_npe_thresh = 0.5


### PR DESCRIPTION
Updated hcana code to have adcTimeWindowMin and Max
  for each Cerenkvo PMT so need to modify the
  adcTimeWindowMin and Max parameters to be an array.
  Keep them at -1000 and 1000 ns .

This adcTimeWindow is used to select which hit in the
 multihit ADC channel is picked as the "good" hit to
 use  later in the analysis.