### PR TITLE
Update recon matrix in HMS and SHMS

### DIFF
--- a/PARAM/HMS/GEN/hcana.param
+++ b/PARAM/HMS/GEN/hcana.param
@@ -24,4 +24,5 @@ hcal_d_cor =  1.66,  1.66
 hcal_layer_names = "1pr 2ta 3ta 4ta"
 
 # The following were defined in REPLAY.PARAM
-h_recon_coeff_filename =    'DATFILES/hms_recon_coeff.dat'  ;hms optics matrix
+;h_recon_coeff_filename =    'DATFILES/hms_recon_coeff.dat'  ;hms optics matrix
+h_recon_coeff_filename =    'DATFILES/hms_recon_coeff_opt2018.dat'  ;hms optics matrix

--- a/PARAM/HMS/GEN/hmsflags_orig_6GeV.param
+++ b/PARAM/HMS/GEN/hmsflags_orig_6GeV.param
@@ -14,8 +14,8 @@
 ;  CMOP matrix elements. If you do change then your hms sieve
 ;  plots will be screwed up.
   hdelta_offset = 0.       ; (%)   hdelta_tar = hdelta_tar + hdelta_offset
-  htheta_offset = 0.  ; (rad) hyp_tar = hyp_tar + htheta_offset
-  hphi_offset   = -4.946337367e-3 ; (rad) hxp_tar = hxp_tar + hphi_offset
+  htheta_offset = 4.83e-5  ; (rad) hyp_tar = hyp_tar + htheta_offset
+  hphi_offset   = -4.73e-3 ; (rad) hxp_tar = hxp_tar + hphi_offset
 ;
 
 ;saturation correction flag
@@ -30,7 +30,7 @@
                           ; Data taken with fields set by field00.f or later should set to 2000.
 ; These offsets are determined from elastic ep data.
 ; central field  correction
-  hpcentral_offset = 0.0 ;    
+  hpcentral_offset = -0.025   
   hthetacentral_offset = 0.000 ; (rad) 
   h_oopcentral_offset = 0.00  ; (rad)
 ; sets hpcentral = hpcentral * ( 1. + hpcentral_offset / 100. )

--- a/PARAM/SHMS/GEN/pcana.param
+++ b/PARAM/SHMS/GEN/pcana.param
@@ -1,7 +1,8 @@
 ; Parameters we need to keep THcHallCSpectrometer Happy
-p_recon_coeff_filename = "DATFILES/SHMS_fr3_rec__order_5.dat"
+;p_recon_coeff_filename = "DATFILES/SHMS_fr3_rec__order_5.dat"
 ;p_recon_coeff_filename = "DATFILES/shms-2011-26cm-monte_q2_p20_rec.dat"
 ;p_recon_coeff_filename = "DATFILES/shms-2011-26cm-monte_q2_m015_rec.dat"
 ;p_recon_coeff_filename = "DATFILES/shms_dipole_2plow.dat"
+p_recon_coeff_filename = "DATFILES/shms-2017-optimized.dat"
 
 

--- a/PARAM/SHMS/GEN/shmsflags.param
+++ b/PARAM/SHMS/GEN/shmsflags.param
@@ -13,7 +13,7 @@
 
 pdelta_offset = 0.0
 ptheta_offset = 0.0
-pphi_offset = 0.0
+pphi_offset = 4.83E-4
 
 ; The following offsets are applied to the central kinematic variables
 ; These might be modified by an experiment


### PR DESCRIPTION
Modify hcana.param and hmsflags.param to use the
  latest matrix fit.

Modify pcana.param and shmsflags.param to use the
  latest matrix fit.