### PR TITLE
Updated gbeam.param with Fall 2018 BPM survey

### DIFF
--- a/PARAM/GEN/gbeam.param
+++ b/PARAM/GEN/gbeam.param
@@ -25,10 +25,18 @@
   gbpmyc_slope = 0.842774
   gbpmyc_off   = 0.549787
 
-;positions of BPMs relative to target (from survey 2017)
-gbpma_zpos = 370.82 ; cm
-gbpmb_zpos = 224.96 ; cm
-gbpmc_zpos = 129.30 ; cm
+;positions of BPMs relative to target (from DIMAD)
+;gbpma_zpos = 370.82 ; cm
+;gbpmb_zpos = 224.96 ; cm
+;gbpmc_zpos = 129.30 ; cm
+;positions of BPMs relative to target (from Fall 2017 survey)
+;gbpma_zpos = 320.42 ; cm
+;gbpmb_zpos = 224.86 ; cm
+;gbpmc_zpos = 129.44 ; cm
+;positions of BPMs relative to target (from Fall 2018 survey)
+gbpma_zpos = 320.17 ; cm
+gbpmb_zpos = 224.81 ; cm
+gbpmc_zpos = 129.38 ; cm
 
 
 ;             Fast Raster calibration constants


### PR DESCRIPTION
The file had been using the BPM z-position
from the DIMAD. Comment these out.

For the record, put in the BPM z-position for the Fall 2017 survey
and commented them out.

Put in the BPM z-positions from the Fall 2018 survey.