### PR TITLE
Updated PARAM/GEN/gbeam.param

### DIFF
--- a/PARAM/GEN/gbeam.param
+++ b/PARAM/GEN/gbeam.param
@@ -10,20 +10,20 @@
   gbeam_yp = +0.00
 
 ; Add new variables for Hall C BPM A, B, and C, based on HARP calibration
-; Edward Brash - August 5, 2018
+; Updated  by Dave Gaskell
 ;
-  gbpmxa_slope = -1.00111
-  gbpmxa_off   = -0.12309
-  gbpmxb_slope = -1.24023
-  gbpmxb_off   = -0.061674
-  gbpmxc_slope = -0.940987
-  gbpmxc_off   = -1.00727
-  gbpmya_slope = 0.957734
-  gbpmya_off   = -0.441772
-  gbpmyb_slope = 1.19394
-  gbpmyb_off   = 0.190904
-  gbpmyc_slope = 0.842774
-  gbpmyc_off   = 0.549787
+  gbpmxa_slope = -0.98
+  gbpmxa_off   = -0.05
+  gbpmxb_slope = -1.12
+  gbpmxb_off   = +0.08
+  gbpmxc_slope = -0.96
+  gbpmxc_off   = -0.89
+  gbpmya_slope = 0.97
+  gbpmya_off   = -0.20
+  gbpmyb_slope = 1.17
+  gbpmyb_off   = 0.38
+  gbpmyc_slope = 0.87
+  gbpmyc_off   = 0.47
 
 ;positions of BPMs relative to target (from DIMAD)
 ;gbpma_zpos = 370.82 ; cm
@@ -47,19 +47,18 @@ gbpmc_zpos = 129.38 ; cm
 ; if 0 then only use average beam pos and angles in calculating beam position
 ; Various fast raster quantities: gUse* are flags
 
+; Raster constants determined from coin run 4556 on Aug 20, 2018
+gfr_cal_mom  = 8.518
+gfrxa_adc_zero_offset = 64150
+gfrxb_adc_zero_offset = 66250
+gfrya_adc_zero_offset = 67700
+gfryb_adc_zero_offset = 64100
+gfrxa_adcpercm = 158000
+gfrxb_adcpercm = 147000
+gfrya_adcpercm = 155500
+gfryb_adcpercm = 157500
 
-  gfr_cal_mom  = 6.4  ; = beam momnetum during jan 2018 3 pass 
-       
-  gfrya_adcpercm = (77755.-57411.)/.2;
-  gfryb_adcpercm = (71093.-52056.)/.2;
-  gfrxa_adcpercm = (75733.-51938.)/.2;
-  gfrxb_adcpercm =  (79778.-57293.)/.2;
-
-  gfrya_adc_zero_offset = (77755.+57411.)/2.;
-  gfryb_adc_zero_offset = (71093.+52056.)/2.;
-  gfrxa_adc_zero_offset = (75733.+51938.)/2.;
-  gfrxb_adc_zero_offset = (79778.+57293.)/2. ;
-
+ 
  
 ; positions of FR magnets relative to target
   gfrx_dist  = 1375   ; cm


### PR DESCRIPTION
Modified BPM parameters to new values
calculated by Dave Gaskell using the
survey BPM z-positions. Before it was
done using the DIMAD z-positions which
were off  (mostly for BPMA).

Updated the raster coefficient using data
from run 4556 on Aug 20,2018