### PR TITLE
Add BPM epics X and Y histograms

### DIFF
--- a/DEF-files/HMS/PRODUCTION/RASTER/hraster_histos.def
+++ b/DEF-files/HMS/PRODUCTION/RASTER/hraster_histos.def
@@ -35,3 +35,14 @@ TH2F hFRBraw_XvsY 'HMS FRB Raw X vs Y; FRXB RAW ADC (Volts); FRYB RAW ADC (Volts
 
 TH2F hFRApos_XvsY 'HMS FRA X vs Y; FRA X Position (cm); FRA Y Position (cm)' H.rb.raster.fr_xa H.rb.raster.fr_ya 40 -0.2 0.2 40 -0.2 0.2 H.dc.ntrack>0
 TH2F hFRBpos_XvsY 'HMS FRB X vs Y; FRB X Position (cm); FRB Y Position (cm)' H.rb.raster.fr_xb H.rb.raster.fr_yb 40 -0.2 0.2 40 -0.2 0.2 H.dc.ntrack>0
+
+TH1F hBPMA_X 'Beam BPMA_X ; BPMA_X  (CM); Counts' H.rb.raster.fr_xbpmA 300 -.3 .3
+TH1F hBPMB_X 'Beam BPMB_X ; BPMB_X  (CM); Counts' H.rb.raster.fr_xbpmB 300 -.3 .3
+TH1F hBPMC_X 'Beam BPMC_X ; BPMC_X  (CM); Counts' H.rb.raster.fr_xbpmC 300 -.3 .3
+TH1F hBPMT_X 'Beam BPMT_X ; BPM_X projected to target  (CM); Counts' H.rb.raster.fr_xbpm_tar 300 -.3 .3
+TH1F hBPMA_Y 'Beam BPMA_Y ; BPMA_Y  (CM); Counts' H.rb.raster.fr_ybpmA 300 -.3 .3
+TH1F hBPMB_Y 'Beam BPMB_Y ; BPMB_Y  (CM); Counts' H.rb.raster.fr_ybpmB 300 -.3 .3
+TH1F hBPMC_Y 'Beam BPMC_Y ; BPMC_Y  (CM); Counts' H.rb.raster.fr_ybpmC 300 -.3 .3
+TH1F hBPMT_Y 'Beam BPMT_Y ; BPM_Y projected to target  (CM); Counts' H.rb.raster.fr_ybpm_tar 300 -.3 .3
+
+

--- a/DEF-files/SHMS/PRODUCTION/RASTER/praster_histos.def
+++ b/DEF-files/SHMS/PRODUCTION/RASTER/praster_histos.def
@@ -35,3 +35,13 @@ TH2F pFRBraw_XvsY 'SHMS FRB Raw X vs Y; FRXB RAW ADC (Volts); FRYB RAW ADC (Volt
 
 TH2F pFRApos_XvsY 'SHMS FRA X vs Y; FRA X Position (cm); FRA Y Position (cm)' P.rb.raster.fr_xa P.rb.raster.fr_ya 40 -0.2 0.2 40 -0.2 0.2 P.dc.ntrack>0
 TH2F pFRBpos_XvsY 'SHMS FRB X vs Y; FRB X Position (cm); FRB Y Position (cm)' P.rb.raster.fr_xb P.rb.raster.fr_yb 40 -0.2 0.2 40 -0.2 0.2 P.dc.ntrack>0
+
+TH1F hBPMA_X 'Beam BPMA_X ; BPMA_X  (CM); Counts' P.rb.raster.fr_xbpmA 300 -.3 .3
+TH1F hBPMB_X 'Beam BPMB_X ; BPMB_X  (CM); Counts' P.rb.raster.fr_xbpmB 300 -.3 .3
+TH1F hBPMC_X 'Beam BPMC_X ; BPMC_X  (CM); Counts' P.rb.raster.fr_xbpmC 300 -.3 .3
+TH1F hBPMT_X 'Beam BPMT_X ; BPM_X projected to target  (CM); Counts' P.rb.raster.fr_xbpm_tar 300 -.3 .3
+TH1F hBPMA_Y 'Beam BPMA_Y ; BPMA_Y  (CM); Counts' P.rb.raster.fr_ybpmA 300 -.3 .3
+TH1F hBPMB_Y 'Beam BPMB_Y ; BPMB_Y  (CM); Counts' P.rb.raster.fr_ybpmB 300 -.3 .3
+TH1F hBPMC_Y 'Beam BPMC_Y ; BPMC_Y  (CM); Counts' P.rb.raster.fr_ybpmC 300 -.3 .3
+TH1F hBPMT_Y 'Beam BPMT_Y ; BPM_Y projected to target  (CM); Counts' P.rb.raster.fr_ybpm_tar 300 -.3 .3
+

--- a/onlineGUI/CONFIG/HMS/PRODUCTION/hms_coin_production.cfg
+++ b/onlineGUI/CONFIG/HMS/PRODUCTION/hms_coin_production.cfg
@@ -142,6 +142,11 @@ title HMS Fast Raster
 hFRApos_XvsY -nostat
 hFRBpos_XvsY -nostat
 
+newpage 2 1
+title HMS EPICS BPM
+macro UTIL/BEAMLINE/plot_beam.C("X")
+macro UTIL/BEAMLINE/plot_beam.C("Y")
+
 newpage 2 2
 title HMS Kinematics
 hdc_trk_mom -nostat

--- a/onlineGUI/CONFIG/HMS/PRODUCTION/hms_production.cfg
+++ b/onlineGUI/CONFIG/HMS/PRODUCTION/hms_production.cfg
@@ -142,6 +142,11 @@ title HMS Fast Raster
 hFRApos_XvsY -nostat
 hFRBpos_XvsY -nostat
 
+newpage 2 1
+title HMS EPICS BPM
+macro UTIL/BEAMLINE/plot_beam.C("X")
+macro UTIL/BEAMLINE/plot_beam.C("Y")
+
 newpage 2 2
 title HMS Kinematics
 hdc_trk_mom -nostat

--- a/onlineGUI/CONFIG/SHMS/PRODUCTION/shms_coin_production.cfg
+++ b/onlineGUI/CONFIG/SHMS/PRODUCTION/shms_coin_production.cfg
@@ -172,6 +172,11 @@ title SHMS Fast Raster
 pFRApos_XvsY -nostat
 pFRBpos_XvsY -nostat
 
+newpage 2 1
+title SHMS EPICS BPM
+macro UTIL/BEAMLINE/plot_beam.C("X")
+macro UTIL/BEAMLINE/plot_beam.C("Y")
+
 newpage 2 2
 title SHMS Kinematics
 pdc_trk_mom -nostat

--- a/onlineGUI/CONFIG/SHMS/PRODUCTION/shms_production.cfg
+++ b/onlineGUI/CONFIG/SHMS/PRODUCTION/shms_production.cfg
@@ -172,6 +172,11 @@ title SHMS Fast Raster
 pFRApos_XvsY -nostat
 pFRBpos_XvsY -nostat
 
+newpage 2 1
+title SHMS EPICS BPM
+macro UTIL/BEAMLINE/plot_beam.C("X")
+macro UTIL/BEAMLINE/plot_beam.C("Y")
+
 newpage 2 2
 title SHMS Kinematics
 pdc_trk_mom -nostat

--- a/onlineGUI/UTIL/BEAMLINE/plot_beam.C
+++ b/onlineGUI/UTIL/BEAMLINE/plot_beam.C
@@ -1,0 +1,33 @@
+void plot_beam(TString dir) {
+  TH1F* h1d[4];
+  if (dir=="Y") {
+  h1d[0] = (TH1F*) gDirectory->Get("hBPMA_Y");
+  h1d[1] = (TH1F*) gDirectory->Get("hBPMB_Y");
+  h1d[2] = (TH1F*) gDirectory->Get("hBPMC_Y");
+  h1d[3] = (TH1F*) gDirectory->Get("hBPMT_Y");
+  } else {
+  h1d[0] = (TH1F*) gDirectory->Get("hBPMA_X");
+  h1d[1] = (TH1F*) gDirectory->Get("hBPMB_X");
+  h1d[2] = (TH1F*) gDirectory->Get("hBPMC_X");
+  h1d[3] = (TH1F*) gDirectory->Get("hBPMT_X");
+  }
+  Double_t mean_x[4];
+     Double_t zbpm[4]={-320.82,-224.86,-129.44,0.};  
+  for (Int_t nb=0;nb<4;nb++) {
+    mean_x[nb]=h1d[nb]->GetMean();
+  }
+  TGraph *grbeamx = new TGraph(4,zbpm,mean_x);
+  if (dir=="Y") grbeamx->SetTitle("; Z BPM (cm); Y BPM (cm) (+Y up) ");
+  if (dir=="X") grbeamx->SetTitle("; Z BPM (cm); X BPM (cm) (+Y up) ");
+    gPad->SetGridy();
+  gPad->SetGridx();
+  grbeamx->SetMarkerStyle(20);
+  grbeamx->SetMarkerSize(1);
+  grbeamx->GetXaxis()->SetLimits(-400,50);
+  grbeamx->SetMinimum(-.5);
+  grbeamx->SetMaximum(.5);
+  grbeamx->Draw("AP");
+
+
+  //
+}


### PR DESCRIPTION
1) Add BPM EPICS X and Y histograms
  to HMS/PRODUCTION/RASTER/hraster_histos.def
and SHMS/PRODUCTION/RASTER/praster_histos.def

2) Add script UTIL/BEAMLINE/plot_beam.C
  to plot the mean of the BPM histograms
   as a function of Z_beam to show the
   beam track on target.

3) Add call plot_beam.C to the production
 config files so that it is included in
the online analysis.