### PR TITLE
Tdc conv fix

### DIFF
--- a/DBASE/COIN/general.param
+++ b/DBASE/COIN/general.param
@@ -9,6 +9,7 @@ cminch=2.54
 #include "PARAM/GEN/gtarget.param"
 #include "PARAM/GEN/gbeam.param"
 #include "PARAM/GEN/gscalers.param"
+#include "PARAM/GEN/gglobal.param"
 
 ; General HMS parameter files
 ; Note: hmsflags.param includes spectrometer offsets and options.

--- a/DBASE/HMS/general.param
+++ b/DBASE/HMS/general.param
@@ -9,6 +9,7 @@ cminch=2.54
 #include "PARAM/GEN/gtarget.param"
 #include "PARAM/GEN/gbeam.param"
 #include "PARAM/GEN/gscalers.param"
+#include "PARAM/GEN/gglobal.param"
 
 ; General HMS parameter files
 ; Note: hmsflags.param includes spectrometer offsets and options.

--- a/DBASE/SHMS/general.param
+++ b/DBASE/SHMS/general.param
@@ -9,6 +9,7 @@ cminch=2.54
 #include "PARAM/GEN/gtarget.param"
 #include "PARAM/GEN/gbeam.param"
 #include "PARAM/GEN/gscalers.param"
+#include "PARAM/GEN/gglobal.param"
 
 ; General SHMS parameter files
 ; Note: shmsflags.param includes spectrometer offsets and options.

--- a/PARAM/GEN/gglobal.param
+++ b/PARAM/GEN/gglobal.param
@@ -1,0 +1,5 @@
+; File to store global parameters
+
+; conversion factor for tdc clicks to ns (CAEN1190 modules)
+; '100 ps' mode, https://logbooks.jlab.org/entry/3574348
+caen1190_convFactor = 0.09766

--- a/PARAM/HMS/DC/hdc_geom.param
+++ b/PARAM/HMS/DC/hdc_geom.param
@@ -3,9 +3,6 @@
 ; Chamber version
  hdc_version = 1
 
-; Conversion factor from TDC clicks to ns.
-hdc_tdc_time_per_channel = -0.09766
-
 ; Number of drift chambers.
 hdc_num_chambers = 2
 

--- a/PARAM/HMS/HODO/hhodo_cuts.param
+++ b/PARAM/HMS/HODO/hhodo_cuts.param
@@ -20,8 +20,6 @@ htofusinginvadc=0
     hscin_tdc_min = -500                                                           
 ; hscin_tdc_max       maximum allowed tdc value                                 
    hscin_tdc_max = 4000                                                         
-; hscin_tdc_to_time   scin tdc time per channel                                 
-   hscin_tdc_to_time = 0.09766   ;0.1 was before Dave Mack found the correct conversion in C1190 Manual (May 14, 2018); (See HC Log Entry 3574348)
 
 ; tof and you figured out good values
    htof_tolerance = 100.0

--- a/PARAM/SHMS/DC/pdc_geom.param
+++ b/PARAM/SHMS/DC/pdc_geom.param
@@ -3,9 +3,6 @@
 ; Chamber version
  pdc_version = 2
 
-; Conversion factor from TDC clicks to ns.
-pdc_tdc_time_per_channel = -0.09766
-
 ; Number of drift chambers.
 pdc_num_chambers = 2
 

--- a/PARAM/SHMS/HODO/phodo_cuts.param
+++ b/PARAM/SHMS/HODO/phodo_cuts.param
@@ -23,9 +23,6 @@ pscin_tdc_min = -500
 ; pscin_tdc_max       maximum allowed tdc value                                 
 pscin_tdc_max = 1000                                                        
 
-; pscin_tdc_to_time   scin tdc time per channel                                 
-pscin_tdc_to_time = 0.09766 ; 0.1 (See Log Entry 3574348)                                                   
-
 ; tof and you figured out good values
 ptof_tolerance = 100.0
                                                                                

--- a/PARAM/TRIG/tshms.param
+++ b/PARAM/TRIG/tshms.param
@@ -3,7 +3,6 @@ t_shms_numTdc = 57
 
 t_shms_tdcoffset = 300.
 t_shms_adc_tdc_offset = 200.
-t_shms_tdcchanperns = 0.09766
 
 ; bar num:          1      2      3      4         5             6          7         8        9        10
 t_shms_adcNames = "pAER pHGCER pNGCER pPSHWR pFADC_TREF_ROC2 pHGCER_MOD pNGCER_MOD pHEL_NEG pHEL_POS pHEL_MPS"


### PR DESCRIPTION
Remove multiple instances of the CAEN 1990 tdc to ns conversion factor and instead utilize single global parameter.

This PR is dependent on the JeffersonLab/hcana commit 948af20