### PR TITLE
Cal calib update

### DIFF
--- a/CALIBRATION/shms_cal_calib/THcPShowerCalib.h
+++ b/CALIBRATION/shms_cal_calib/THcPShowerCalib.h
@@ -119,6 +119,8 @@ class THcPShowerCalib {
 
   Double_t        P_hgcer_npe[4];
   Double_t        P_ngcer_npe[4];
+  Double_t        P_ngcer_npeSum;
+  Double_t        P_hgcer_npeSum;
   Double_t        P_tr_beta;
 
   Double_t        P_cal_nclust;          //Preshower
@@ -141,6 +143,8 @@ class THcPShowerCalib {
   TBranch* b_P_tr_tg_y;
   TBranch* b_P_hgcer_npe;
   TBranch* b_P_ngcer_npe;
+  TBranch* b_P_hgcer_npeSum;
+  TBranch* b_P_ngcer_npeSum;
   TBranch* b_P_tr_beta;
 
   TBranch* b_P_cal_nclust;
@@ -360,22 +364,22 @@ void THcPShowerCalib::Init() {
   fTree->SetBranchAddress("P.cal.fly.goodAdcPulseInt",  P_sh_a_p,
 			  &b_P_sh_a_p);
 
-  fTree->SetBranchAddress("P.tr.n", &P_tr_n,&b_P_tr_n);
-  fTree->SetBranchAddress("P.tr.x", &P_tr_x,&b_P_tr_x);
-  fTree->SetBranchAddress("P.tr.y", &P_tr_y,&b_P_tr_y);
-  fTree->SetBranchAddress("P.tr.th",&P_tr_xp,&b_P_tr_xp);
-  fTree->SetBranchAddress("P.tr.ph",&P_tr_yp,&b_P_tr_yp);
-  fTree->SetBranchAddress("P.tr.p", &P_tr_p,&b_P_tr_p);
+  fTree->SetBranchAddress("P.dc.ntrack", &P_tr_n,&b_P_tr_n);
+  fTree->SetBranchAddress("P.dc.x_fp", &P_tr_x,&b_P_tr_x);
+  fTree->SetBranchAddress("P.dc.y_fp", &P_tr_y,&b_P_tr_y);
+  fTree->SetBranchAddress("P.dc.xp_fp",&P_tr_xp,&b_P_tr_xp);
+  fTree->SetBranchAddress("P.dc.yp_fp",&P_tr_yp,&b_P_tr_yp);
+  fTree->SetBranchAddress("P.gtr.p", &P_tr_p,&b_P_tr_p);
 
-  fTree->SetBranchAddress("P.tr.tg_dp", &P_tr_tg_dp,&b_P_tr_tg_dp);
-  fTree->SetBranchAddress("P.tr.tg_ph", &P_tr_tg_ph,&b_P_tr_tg_ph);
-  fTree->SetBranchAddress("P.tr.tg_th", &P_tr_tg_th,&b_P_tr_tg_th);
-  fTree->SetBranchAddress("P.tr.tg_y",  &P_tr_tg_y, &b_P_tr_tg_y);
+  fTree->SetBranchAddress("P.gtr.dp", &P_tr_tg_dp,&b_P_tr_tg_dp);
+  fTree->SetBranchAddress("P.gtr.ph", &P_tr_tg_ph,&b_P_tr_tg_ph);
+  fTree->SetBranchAddress("P.gtr.th", &P_tr_tg_th,&b_P_tr_tg_th);
+  fTree->SetBranchAddress("P.gtr.y",  &P_tr_tg_y, &b_P_tr_tg_y);
  
-  fTree->SetBranchAddress("P.hgcer.npe", P_hgcer_npe,&b_P_hgcer_npe);
-  fTree->SetBranchAddress("P.ngcer.npe", P_ngcer_npe,&b_P_ngcer_npe);
+  fTree->SetBranchAddress("P.hgcer.npeSum", &P_hgcer_npeSum,&b_P_hgcer_npeSum);
+  fTree->SetBranchAddress("P.ngcer.npeSum", &P_ngcer_npeSum,&b_P_ngcer_npeSum);
 
-  fTree->SetBranchAddress("P.tr.beta", &P_tr_beta,&b_P_tr_beta);
+  fTree->SetBranchAddress("P.hod.beta", &P_tr_beta,&b_P_tr_beta);
 
   fTree->SetBranchAddress("P.cal.nclust", &P_cal_nclust,&b_P_cal_nclust);
   fTree->SetBranchAddress("P.cal.ntracks", &P_cal_ntracks,&b_P_cal_ntracks);
@@ -538,16 +542,10 @@ bool THcPShowerCalib::ReadShRawTrack(THcPShTrack &trk, UInt_t ientry) {
   good_trk = P_tr_xp > -0.045+0.0025*P_tr_x;
   if (!good_trk) return 0;
 
-    bool good_ngcer = P_ngcer_npe[0] > fNGCerMin ||
-  		    P_ngcer_npe[1] > fNGCerMin ||
-  		    P_ngcer_npe[2] > fNGCerMin ||
-  		    P_ngcer_npe[3] > fNGCerMin  ;
+    bool good_ngcer = P_ngcer_npeSum >= fNGCerMin ;
     if(!good_ngcer) return 0;
 
-  bool good_hgcer = P_hgcer_npe[0] +
-		    P_hgcer_npe[1] +
-		    P_hgcer_npe[2] +
-		    P_hgcer_npe[3] > fHGCerMin  ;
+  bool good_hgcer = P_hgcer_npeSum >= fHGCerMin  ;
   if(!good_hgcer) return 0;
 
   bool good_beta = P_tr_beta > fBetaMin &&


### PR DESCRIPTION
Update THcShowerCalib in shms_cal_calib and hms_cal_calib

Recently ROOT had a problem with the way that the track "tr" variables which are array
 were being read-in the code. Decide just to use the "gtr" variables which are not arrays.

Update hms_cal_calib THcShowerCalib.h

Used the "golden" track, gtr , variables
instead of "tr" variables.

Used H.cer.NpeSum instead of individual
H.cer.npe[0] and [1]

USe H.hod.beta instead of H.tr.beta

Updated shms_cal_calib/THcPShowerCalib.h

Use the golden track, "gtr" or drift chamber "dc",
"dc" instead of "tr" variables.

use npeSum instead of individual
npe for Cherenkov.

Use hod.beta instead of tr.beta

