### PR TITLE
Changed x, y, x' and y' to golden track focal plane quantities

### DIFF
--- a/CALIBRATION/hms_cal_calib/THcShowerCalib.h
+++ b/CALIBRATION/hms_cal_calib/THcShowerCalib.h
@@ -346,10 +346,10 @@ void THcShowerCalib::Init() {
 			  &b_H_cal_4ta_apos_p);
 
   fTree->SetBranchAddress("H.dc.ntrack", &H_tr_n,&b_H_tr_n);
-  fTree->SetBranchAddress("H.gtr.x",&H_tr_x,&b_H_tr_x);
-  fTree->SetBranchAddress("H.gtr.y",&H_tr_y,&b_H_tr_y);
-  fTree->SetBranchAddress("H.gtr.th",&H_tr_xp,&b_H_tr_xp);
-  fTree->SetBranchAddress("H.gtr.ph",&H_tr_yp,&b_H_tr_yp);
+  fTree->SetBranchAddress("H.gtr.x_fp",&H_tr_x,&b_H_tr_x);
+  fTree->SetBranchAddress("H.gtr.y_fp",&H_tr_y,&b_H_tr_y);
+  fTree->SetBranchAddress("H.gtr.xp_fp",&H_tr_xp,&b_H_tr_xp);
+  fTree->SetBranchAddress("H.gtr.yp_fp",&H_tr_yp,&b_H_tr_yp);
   fTree->SetBranchAddress("H.gtr.p",&H_tr_p,&b_H_tr_p);
 
   fTree->SetBranchAddress("H.gtr.dp", &H_tr_tg_dp,&b_H_tr_tg_dp);

--- a/CALIBRATION/shms_cal_calib/THcPShowerCalib.h
+++ b/CALIBRATION/shms_cal_calib/THcPShowerCalib.h
@@ -365,10 +365,10 @@ void THcPShowerCalib::Init() {
 			  &b_P_sh_a_p);
 
   fTree->SetBranchAddress("P.dc.ntrack", &P_tr_n,&b_P_tr_n);
-  fTree->SetBranchAddress("P.dc.x_fp", &P_tr_x,&b_P_tr_x);
-  fTree->SetBranchAddress("P.dc.y_fp", &P_tr_y,&b_P_tr_y);
-  fTree->SetBranchAddress("P.dc.xp_fp",&P_tr_xp,&b_P_tr_xp);
-  fTree->SetBranchAddress("P.dc.yp_fp",&P_tr_yp,&b_P_tr_yp);
+  fTree->SetBranchAddress("P.gtr.x_fp", &P_tr_x,&b_P_tr_x);
+  fTree->SetBranchAddress("P.gtr.y_fp", &P_tr_y,&b_P_tr_y);
+  fTree->SetBranchAddress("P.gtr.xp_fp",&P_tr_xp,&b_P_tr_xp);
+  fTree->SetBranchAddress("P.gtr.yp_fp",&P_tr_yp,&b_P_tr_yp);
   fTree->SetBranchAddress("P.gtr.p", &P_tr_p,&b_P_tr_p);
 
   fTree->SetBranchAddress("P.gtr.dp", &P_tr_tg_dp,&b_P_tr_tg_dp);


### PR DESCRIPTION
Changed x, y, x' and y' to golden track focal plane quantities.  Before the HMS code was using target variables and the SHMS code was using drift chamber variables.  I made them both golden track focal plane variables to be consistent.