### PR TITLE
Fix Bug in bcm calibration and  6GeV elec. livetimes. also changed Trk Eff definition. 

### DIFF
--- a/CALIBRATION/bcm_current_map/ScalerCalib.C
+++ b/CALIBRATION/bcm_current_map/ScalerCalib.C
@@ -104,6 +104,7 @@ int ScalerCalib::PrintContainer(ScalerContainer sc)
 
   for(SCIterator i = sc.begin(); i != sc.end()-1; ++i)
     {
+      if(*i<=1E6)outfile<<std::fixed<<std.setprecision(0);
       outfile << *i << ", ";
     }
   

--- a/CALIBRATION/bcm_current_map/ScalerCalib.C
+++ b/CALIBRATION/bcm_current_map/ScalerCalib.C
@@ -104,7 +104,7 @@ int ScalerCalib::PrintContainer(ScalerContainer sc)
 
   for(SCIterator i = sc.begin(); i != sc.end()-1; ++i)
     {
-      if(*i<=1E6)outfile<<std::fixed<<std.setprecision(0);
+      if(*i<=1E6)outfile<<std::fixed<<std::setprecision(0);
       outfile << *i << ", ";
     }
   

--- a/DEF-files/HMS/PRODUCTION/CUTS/hstackana_reconstruct_cuts.def
+++ b/DEF-files/HMS/PRODUCTION/CUTS/hstackana_reconstruct_cuts.def
@@ -9,7 +9,7 @@ HMSScinGood           H.hod.goodscinhit == 1
 HMSGoodBetanotrk      H.hod.betanotrack > 0.8 && H.hod.betanotrack < 1.3
 
 
-HMSScinShould         HMSScinGood && HMSGoodBetanotrk && !hmsDCany_large
+HMSScinShould         HMSScinGood && HMSGoodBetanotrk
 HMSScinShoulde        HMSScinShould && H.cal.etotnorm > 0.6&& H.cal.etotnorm < 2.0&& H.cer.npeSum > 0.5
 HMSScinShouldh        HMSScinGood && H.cal.etotnorm <0.6&& H.cal.etotnorm>0.0&& H.cer.npeSum < 0.5
 

--- a/DEF-files/SHMS/PRODUCTION/CUTS/pstackana_reconstruct_cuts.def
+++ b/DEF-files/SHMS/PRODUCTION/CUTS/pstackana_reconstruct_cuts.def
@@ -14,7 +14,7 @@ pcut_pi_all            	  pcut_cer_ng_pi && pcut_cer_hg_pi && pcut_cal_pi
 shmsScinGood        P.hod.goodscinhit == 1
 shmsGoodBetanotrk   P.hod.betanotrack > 0.5 && P.hod.betanotrack < 1.4
 
-shmsScinShould      shmsScinGood && shmsGoodBetanotrk && !shmsDCany_large 
+shmsScinShould      shmsScinGood && shmsGoodBetanotrk
 shmsScinShoulde     shmsScinShould &&  P.cal.etotnorm > 0.6 && P.cal.etotnorm < 1.6 && P.hgcer.npeSum > 0.5
 #shmsScinShouldh     shmsScinShould && P.cal.etotnorm <= 0.6 && P.cal.etotnorm > 0. && P.hgcer.npeSum < 0.2
 shmsScinShouldh     shmsScinShould && P.cal.etotnorm <= 0.6 && P.cal.etotnorm > 0.

--- a/TEMPLATES/HMS/PRODUCTION/hstackana_production.template
+++ b/TEMPLATES/HMS/PRODUCTION/hstackana_production.template
@@ -154,13 +154,13 @@ Pre-Scaled Ps2 Total Dead Time (EDTM) : {100.0 - (hcut_edtm_accepted.npassed / (
 Pre-Scaled Ps3 Total Live Time (EDTM) : {(hcut_edtm_accepted.npassed / (H.EDTM.scaler/ghconfig_ti_ps_factors[2]))*100.0:%3.4f} %
 Pre-Scaled Ps3 Total Dead Time (EDTM) : {100.0 - (hcut_edtm_accepted.npassed / (H.EDTM.scaler/ghconfig_ti_ps_factors[2]))*100.0:%3.4f} %
 
-OG 6 GeV Electronic Live Time (100, 150) : {100.0 - ((H.pPRE100.scalerCut - H.pPRE150.scalerCut)/H.pPRE100.scalerCut):%3.4f} %
+OG 6 GeV Electronic Live Time (100, 150) : {100.0*(1. - ((H.pPRE100.scalerCut - H.pPRE150.scalerCut)/H.pPRE100.scalerCut)):%3.4f} %
 OG 6 GeV Electronic Dead Time (100, 150) : {100*((H.pPRE100.scalerCut - H.pPRE150.scalerCut)/H.pPRE100.scalerCut):%3.4f} %
 
-OG 6 GeV Electronic Live Time (100, 200) : {100.0 - ((H.pPRE100.scalerCut - H.pPRE200.scalerCut)/H.pPRE100.scalerCut):%3.4f} %
+OG 6 GeV Electronic Live Time (100, 200) : {100.0*(1. - ((H.pPRE100.scalerCut - H.pPRE200.scalerCut)/H.pPRE100.scalerCut)):%3.4f} %
 OG 6 GeV Electronic Dead Time (100, 200) : {100*((H.pPRE100.scalerCut - H.pPRE200.scalerCut)/H.pPRE100.scalerCut):%3.4f} %
 
-OG 6 GeV Electronic Live Time (150, 200) : {100.0 - ((H.pPRE150.scalerCut - H.pPRE200.scalerCut)/H.pPRE150.scalerCut):%3.4f} %
+OG 6 GeV Electronic Live Time (150, 200) : {100.0*(1. - ((H.pPRE150.scalerCut - H.pPRE200.scalerCut)/H.pPRE150.scalerCut)):%3.4f} %
 OG 6 GeV Electronic Dead Time (150, 200) : {100*((H.pPRE150.scalerCut - H.pPRE200.scalerCut)/H.pPRE150.scalerCut):%3.4f} %
 
 3/4      Pre-Trigger 50 ns Gate  : {H.hTRIG1.scalerCut/H.1MHz.scalerTimeCut/1000.:%.3f} kHz

--- a/TEMPLATES/SHMS/PRODUCTION/pstackana_production.template
+++ b/TEMPLATES/SHMS/PRODUCTION/pstackana_production.template
@@ -160,13 +160,13 @@ Pre-Scaled Ps2 Total Dead Time (EDTM) : {100.0 - (pcut_edtm_accepted.npassed / (
 Pre-Scaled Ps3 Total Live Time (EDTM) : {(pcut_edtm_accepted.npassed / (P.EDTM.scaler/gpconfig_ti_ps_factors[2]))*100.0:%3.4f} %
 Pre-Scaled Ps3 Total Dead Time (EDTM) : {100.0 - (pcut_edtm_accepted.npassed / (P.EDTM.scaler/gpconfig_ti_ps_factors[2]))*100.0:%3.4f} %
 
-OG 6 GeV Electronic Live Time (100, 150) : {100.0 - ((P.pPRE100.scalerCut - P.pPRE150.scalerCut)/P.pPRE100.scalerCut ):%3.4f} %
+OG 6 GeV Electronic Live Time (100, 150) : {100.0*(1. - ((P.pPRE100.scalerCut - P.pPRE150.scalerCut)/P.pPRE100.scalerCut )):%3.4f} %
 OG 6 GeV Electronic Dead Time (100, 150) : {100*((P.pPRE100.scalerCut  - P.pPRE150.scalerCut)/P.pPRE100.scalerCut):%3.4f} %
 
-OG 6 GeV Electronic Live Time (100, 200) : {100.0 - ((P.pPRE100.scalerCut - P.pPRE200.scalerCut)/P.pPRE100.scalerCut):%3.4f} %
+OG 6 GeV Electronic Live Time (100, 200) : {100.0*(1. - ((P.pPRE100.scalerCut - P.pPRE200.scalerCut)/P.pPRE100.scalerCut)):%3.4f} %
 OG 6 GeV Electronic Dead Time (100, 200) : {100*((P.pPRE100.scalerCut - P.pPRE200.scalerCut)/P.pPRE100.scalerCut):%3.4f} %
 
-OG 6 GeV Electronic Live Time (150, 200) : {100.0 - ((P.pPRE150.scalerCut - P.pPRE200.scalerCut)/P.pPRE150.scalerCut):%3.4f} %
+OG 6 GeV Electronic Live Time (150, 200) : {100.0*(1. - ((P.pPRE150.scalerCut - P.pPRE200.scalerCut)/P.pPRE150.scalerCut)):%3.4f} %
 OG 6 GeV Electronic Dead Time (150, 200) : {100*((P.pPRE150.scalerCut - P.pPRE200.scalerCut)/P.pPRE150.scalerCut):%3.4f} %
 
 3/4      Pre-Trigger 50 ns Gate  : {P.pTRIG1.scalerCut/P.1MHz.scalerTimeCut/1000.:%.3f} kHz


### PR DESCRIPTION
1) Fixed issue when creating BCM PARAM files
2) Fixed 6 GeV elec. livetime calculation in report file
3) Removed DC hit requirement in "should" definition of tracking efficiency

I presented this fixes here and must have forgotten to submit them.
https://hallcweb.jlab.org/DocDB/0010/001081/001/hallc_replayNotes_Aug6th2020.pdf