### PR TITLE
Fix to elec. livetime calculation in report file and bcm param file creation

### DIFF
--- a/CALIBRATION/bcm_current_map/ScalerCalib.C
+++ b/CALIBRATION/bcm_current_map/ScalerCalib.C
@@ -104,6 +104,7 @@ int ScalerCalib::PrintContainer(ScalerContainer sc)
 
   for(SCIterator i = sc.begin(); i != sc.end()-1; ++i)
     {
+      if(*i<=1E6)outfile<<std::fixed<<std::setprecision(0);
       outfile << *i << ", ";
     }
   

--- a/TEMPLATES/HMS/PRODUCTION/hstackana_production.template
+++ b/TEMPLATES/HMS/PRODUCTION/hstackana_production.template
@@ -158,13 +158,13 @@ Pre-Scaled Ps2 Total Dead Time (EDTM) : {100.0 - (hcut_edtm_accepted.npassed / (
 Pre-Scaled Ps3 Total Live Time (EDTM) : {(hcut_edtm_accepted.npassed / (H.EDTM.scaler/ghconfig_ti_ps_factors[2]))*100.0:%3.4f} %
 Pre-Scaled Ps3 Total Dead Time (EDTM) : {100.0 - (hcut_edtm_accepted.npassed / (H.EDTM.scaler/ghconfig_ti_ps_factors[2]))*100.0:%3.4f} %
 
-OG 6 GeV Electronic Live Time (100, 150) : {100.0 - ((H.pPRE100.scalerCut - H.pPRE150.scalerCut)/H.pPRE100.scalerCut):%3.4f} %
+OG 6 GeV Electronic Live Time (100, 150) : {100.0*(1. - ((H.pPRE100.scalerCut - H.pPRE150.scalerCut)/H.pPRE100.scalerCut)):%3.4f} %
 OG 6 GeV Electronic Dead Time (100, 150) : {100*((H.pPRE100.scalerCut - H.pPRE150.scalerCut)/H.pPRE100.scalerCut):%3.4f} %
 
-OG 6 GeV Electronic Live Time (100, 200) : {100.0 - ((H.pPRE100.scalerCut - H.pPRE200.scalerCut)/H.pPRE100.scalerCut):%3.4f} %
+OG 6 GeV Electronic Live Time (100, 200) : {100.0*(1. - ((H.pPRE100.scalerCut - H.pPRE200.scalerCut)/H.pPRE100.scalerCut)):%3.4f} %
 OG 6 GeV Electronic Dead Time (100, 200) : {100*((H.pPRE100.scalerCut - H.pPRE200.scalerCut)/H.pPRE100.scalerCut):%3.4f} %
 
-OG 6 GeV Electronic Live Time (150, 200) : {100.0 - ((H.pPRE150.scalerCut - H.pPRE200.scalerCut)/H.pPRE150.scalerCut):%3.4f} %
+OG 6 GeV Electronic Live Time (150, 200) : {100.0*(1. - ((H.pPRE150.scalerCut - H.pPRE200.scalerCut)/H.pPRE150.scalerCut)):%3.4f} %
 OG 6 GeV Electronic Dead Time (150, 200) : {100*((H.pPRE150.scalerCut - H.pPRE200.scalerCut)/H.pPRE150.scalerCut):%3.4f} %
 
 3/4      Pre-Trigger 50 ns Gate  : {H.hTRIG1.scalerCut/H.1MHz.scalerTimeCut/1000.:%.3f} kHz

--- a/TEMPLATES/SHMS/PRODUCTION/pstackana_production.template
+++ b/TEMPLATES/SHMS/PRODUCTION/pstackana_production.template
@@ -155,13 +155,13 @@ Pre-Scaled Ps2 Total Dead Time (EDTM) : {100.0 - (pcut_edtm_accepted.npassed / (
 Pre-Scaled Ps3 Total Live Time (EDTM) : {(pcut_edtm_accepted.npassed / (P.EDTM.scaler/gpconfig_ti_ps_factors[2]))*100.0:%3.4f} %
 Pre-Scaled Ps3 Total Dead Time (EDTM) : {100.0 - (pcut_edtm_accepted.npassed / (P.EDTM.scaler/gpconfig_ti_ps_factors[2]))*100.0:%3.4f} %
 
-OG 6 GeV Electronic Live Time (100, 150) : {100.0 - ((P.pPRE100.scalerCut - P.pPRE150.scalerCut)/P.pPRE100.scalerCut ):%3.4f} %
+OG 6 GeV Electronic Live Time (100, 150) : {100.0*(1. - ((P.pPRE100.scalerCut - P.pPRE150.scalerCut)/P.pPRE100.scalerCut )):%3.4f} %
 OG 6 GeV Electronic Dead Time (100, 150) : {100*((P.pPRE100.scalerCut  - P.pPRE150.scalerCut)/P.pPRE100.scalerCut):%3.4f} %
 
-OG 6 GeV Electronic Live Time (100, 200) : {100.0 - ((P.pPRE100.scalerCut - P.pPRE200.scalerCut)/P.pPRE100.scalerCut):%3.4f} %
+OG 6 GeV Electronic Live Time (100, 200) : {100.0*(1. - ((P.pPRE100.scalerCut - P.pPRE200.scalerCut)/P.pPRE100.scalerCut)):%3.4f} %
 OG 6 GeV Electronic Dead Time (100, 200) : {100*((P.pPRE100.scalerCut - P.pPRE200.scalerCut)/P.pPRE100.scalerCut):%3.4f} %
 
-OG 6 GeV Electronic Live Time (150, 200) : {100.0 - ((P.pPRE150.scalerCut - P.pPRE200.scalerCut)/P.pPRE150.scalerCut):%3.4f} %
+OG 6 GeV Electronic Live Time (150, 200) : {100.0*(1. - ((P.pPRE150.scalerCut - P.pPRE200.scalerCut)/P.pPRE150.scalerCut)):%3.4f} %
 OG 6 GeV Electronic Dead Time (150, 200) : {100*((P.pPRE150.scalerCut - P.pPRE200.scalerCut)/P.pPRE150.scalerCut):%3.4f} %
 
 3/4      Pre-Trigger 50 ns Gate  : {P.pTRIG1.scalerCut/P.1MHz.scalerTimeCut/1000.:%.3f} kHz


### PR DESCRIPTION
1) Fixed issue when creating BCM PARAM files
2) Fixed 6 GeV elec. livetime calculation in report file

I presented this fixes here and must have forgotten to submit them.
https://hallcweb.jlab.org/DocDB/0010/001081/001/hallc_replayNotes_Aug6th2020.pdf
