### PR TITLE
On branch shms_hodo_work

### DIFF
--- a/CALIBRATION/shms_hodo_calib/fitHodoCalib.C
+++ b/CALIBRATION/shms_hodo_calib/fitHodoCalib.C
@@ -2,12 +2,25 @@
   and time offsets between paddles in different planes
   Author: Carlos Yero
   Dated: June 5, 2018
+  For more information, see the hodo calibration document v2 at https://hallcweb.jlab.org/doc-private/ShowDocument?docid=970 . 
 */
+
+// December 2021 changes: 
+// Velocity constraints were added since background and/or a too-small spot size were leading to unphysically high light propagation velocities.  
+// January 2022 changes:
+// A single paddle hit per plane requirement was added because the fitted velocity and mean time resolution were biased toward significantly larger values due to random hit backgrounds at high SHMS rates.
+// As a compromise between simplicity and efficiency, no explicit matching of tracks to hit hodo paddles is done. This is referred to below as "track matching lite". 
+ 
+// USER RESPONSIBILITIES:
+// This program uses electrons for hodoscope calibrations. The user is responsible for setting PID and beta cuts. These are flagged by the comment line "//ePID CUT NOTICE" below.
+// Rough cuts are applied to various times and TDC values. These need only change when there is a significant trigger change. These are flagged by the comment line "//HARD CUT NOTICE" below. 
+
 
 #include <TMatrixD.h>
 #include <TVectorD.h>
 #include <TDecompSVD.h>
 #include <TSystem.h>
+#include <time.h> 
 #include <TString.h>
 #include "TFile.h"
 #include "TTree.h"
@@ -29,17 +42,28 @@
 #include <TObjArray.h>
 #include <TF1.h>
 
+// C.Y. Jan 22, 2021
+// Added headers necessary for parsing
+// and reading existing parameter files
+// (this is to be used to beta calculation within this code)
+#include "parse_utils.h"
+#include "hallc_parse_utils.h"
+
 void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
 {
 
   gStyle->SetOptFit();  
   gROOT->SetBatch(kTRUE);    //do not display plots
 
+  // Initialize the analysis clock
+  clock_t t;
+  t = clock();
 
-
-  Int_t evtNUM = 30000; // evtNUm is max number in the fit array
-  TFile *data_file = new TFile(filename, "READ"); 
+  // changed this from 30000 N.H. 10 Sept 2021
+  Int_t evtNUM = 1000000; // evtNUm is max number in the fit array
+  TFile *data_file = new TFile(filename, "UPDATE"); 
   TTree *T = (TTree*)data_file->Get("T");
+
 
   //Create output root file where histograms will be stored
   TFile *outROOT = new TFile(Form("HodoCalibPlots_%d.root", runNUM), "recreate");
@@ -47,10 +71,10 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
   /******Define Fixed Quantities********/
   static const Int_t PLANES = 4;
   static const Int_t SIDES = 2;
-  TString spec = "P";
-  TString det = "hod";
-  string pl_names[4] = {"1x", "1y", "2x", "2y"};
-  string side_names[2] = {"GoodPos", "GoodNeg"};
+  static const TString spec = "P";
+  static const TString det = "hod";
+  static const string pl_names[4] = {"1x", "1y", "2x", "2y"};
+  static const string side_names[2] = {"GoodPos", "GoodNeg"};
   string nsign[2] = {"+", "-"};
   Int_t maxPMT[4] = {13, 13, 14, 21};
   Int_t refPad[4] = {0, 13, 26, 40};              //use as reference when counting bars up to 61 
@@ -61,9 +85,26 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
   Double_t phodo_sigArr[PLANES][21] = {0.0};       //store phodo sigma parameters
   Double_t vp = 30.0;                             //speed of light [cm/ns]
 
+  // C. Yero Nov 09, 2021 | Added velocity variation (phodo_velVar) about the set valued for hodoscope paddle velocity fits
+  // If the fitted velocity is out of the boundary: phodo_velSet +/- phodo_velVar, the default velocity value (phodo_velSet) will be set accordingly.
+  // UNITS: cm / ns
+  Double_t phodo_velVar = 3.0;  // This tolerance parameter can be changed to allow larger variations in the velocities. The value 3.0 seems a reasonable compromise. 
+
+  // velocities set (determined by averaging the velocities over all relevant scintillator paddles that had sufficient statistics for a good fit)
+  //                                S1X,   S1Y,   S2X,   S2Y
+  // Out-of-bounds velocities from a failed fit or low statistics will be set to phodo_velSet
+  Double_t phodo_velSet[PLANES] = {15.75, 15.75, 15.75, 14.0};  //good averaged velocities to be used, in case that fit fails or is out of range
+
+  //velocity Min/Max boundaries 
+  Double_t phodo_velMin[PLANES] = {phodo_velSet[0]-phodo_velVar, phodo_velSet[1]-phodo_velVar, phodo_velSet[2]-phodo_velVar, phodo_velSet[3]-phodo_velVar};
+  Double_t phodo_velMax[PLANES] = {phodo_velSet[0]+phodo_velVar, phodo_velSet[1]+phodo_velVar, phodo_velSet[2]+phodo_velVar, phodo_velSet[3]+phodo_velVar};
+  
+
+  //--------------------------------------------
+  
   if (cosmic_flag) {
     vp= -vp;
-    cout << " Spedd of light set to negative number for cosmics" << endl;
+    cout << " Speed of light set to negative number for cosmics" << endl;
   }
 
   /******Define Leafs to be read from TTree******/
@@ -81,12 +122,17 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
   
   TString npcal_etrkNorm = "P.cal.etracknorm";
   TString npngcer_npeSum = "P.hgcer.npeSum";
+  //TString npngcer_npeSum = "P.ngcer.npeSum";                                                                          
   TString npdc_ntrack = "P.dc.ntrack";
   TString nhod_nhits = "nhits";
   TString nbeta = "P.hod.betanotrack";
 
+  TString npdc_xpfp = "P.dc.xp_fp";
+  TString npdc_ypfp = "P.dc.yp_fp";
+  
+  //ePID CUT NOTICE
   Double_t etrknrm_low_cut = 0.7;
-  Double_t npngcer_npeSum_low_cut = 0.7;
+  Double_t npngcer_npeSum_low_cut = 0.5;
   Double_t betanotrack_low_cut = 0.5;
   Double_t betanotrack_hi_cut = 1.5;
 
@@ -108,6 +154,8 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
   Double_t pdc_ntrack;
   Double_t hod_nhits[PLANES];
   Double_t beta;
+
+  Double_t pdc_xpfp, pdc_ypfp;
   
   /******Define Matrices/Vectors and related *******/
   Int_t good_pad[PLANES];                   //keep track of good paddle hits
@@ -119,7 +167,6 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
  
   Int_t row1, row2, row3, row4, row5, row6;   //keep track of ith row element
   Int_t cnt;                                  //keep track of good plane hits
-    
 
   //L*x = b Linear Matrix System
   TVectorD bVec(npar);
@@ -157,7 +204,7 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
   //Determine Corrected z distance / paddle
   for(int ipl = 0; ipl < PLANES; ipl++)
     {
-      cout << "Plane: " << ipl << endl;
+      //cout << "Plane: " << ipl << endl;
       for(int ibar = 0; ibar < maxPMT[ipl]; ibar++)
 	{
 	  z[ipl][ibar] = 0.0;
@@ -165,11 +212,37 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
 	}
 
     }
-                                                                                    
 
+  /**** Define new variables and branches to be added *****/
+
+  //C.Y. Jan 01, 2021 | good plane hit counter variable
+  Int_t good_hod_1x_nhits;
+  Int_t good_hod_1y_nhits;
+  Int_t good_hod_2x_nhits;
+  Int_t good_hod_2y_nhits;
+  Bool_t single_hit_flg;
+  
+
+  //C.Y. Jan 02, 2021 | add new branch
+  TBranch *br_good_hod_1x_nhits = T->Branch("br_good_hod_1x_hit", &good_hod_1x_nhits, "good_hod_1x_nhits/I");
+  TBranch *br_good_hod_1y_nhits = T->Branch("br_good_hod_1y_hit", &good_hod_1y_nhits, "good_hod_1y_nhits/I");
+  TBranch *br_good_hod_2x_nhits = T->Branch("br_good_hod_2x_hit", &good_hod_2x_nhits, "good_hod_2x_nhits/I");
+  TBranch *br_good_hod_2y_nhits = T->Branch("br_good_hod_2y_hit", &good_hod_2y_nhits, "good_hod_2y_nhits/I");
+  TBranch *br_single_hit_flg    = T->Branch("br_single_hit_flg",  &single_hit_flg,    "single_hit_flg/b");
+   
+  
   /*******Define Canvas and Histograms*******/
 
   //----Canvas----
+  TCanvas *beta_calibWeighted_canv = new TCanvas("beta_calib_weight", "SHMS Hodo Beta Calibrated (w/ Tracking + Weight)", 1000, 700);
+  TCanvas *beta_calibUnweighted_canv = new TCanvas("beta_calib_noweight", "SHMS Hodo Beta Calibrated (w/ Tracking + Weight=1)", 1000, 700);
+  
+  TCanvas *good_hod1x_Hit_canv = new TCanvas("good_hod_1x_hits", "Good 1X Plane Hits", 1000, 700);
+  TCanvas *good_hod1y_Hit_canv = new TCanvas("good_hod_1y_hits", "Good 1Y Plane Hits", 1000, 700);
+  TCanvas *good_hod2x_Hit_canv = new TCanvas("good_hod_2x_hits", "Good 2X Plane Hits", 1000, 700);
+  TCanvas *good_hod2y_Hit_canv = new TCanvas("good_hod_2y_hits", "Good 2Y Plane Hits", 1000, 700);
+  TCanvas *good_hodSingleHit_canv = new TCanvas("good_hodSingleHit", "Good Hodo Single Hit Per Plane Flag", 1000, 700); 
+
   TCanvas *TWAvg_canv[PLANES];
   TCanvas *TWAvg_canv_2D[PLANES];
   TCanvas *Diff_TWDistTrkPos_canv[PLANES];
@@ -180,6 +253,12 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
   TCanvas *TWDiff_v_TrkPos_canv[PLANES];
 
   //----Histograms----
+  TH1F *H_good_hod1x_nhits = new TH1F("good_hod1x_nhits", "Good Hodo 1X Hits", 100, 0, 25);
+  TH1F *H_good_hod1y_nhits = new TH1F("good_hod1y_nhits", "Good Hodo 1Y Hits", 100, 0, 25);  
+  TH1F *H_good_hod2x_nhits = new TH1F("good_hod2x_nhits", "Good Hodo 2X Hits", 100, 0, 25);  
+  TH1F *H_good_hod2y_nhits = new TH1F("good_hod2y_nhits", "Good Hodo 2Y Hits", 100, 0, 25);  
+  TH1F *H_good_hod_nhits = new TH1F("good_hod_nhits", "Good Hodo Single Hit per Plane", 100, -1,2);
+
   TH1F *h1Hist_TWAvg[PLANES][21];                    // (TWCorr_Pos + TWCorr_Neg) / 2       <------- 
   TH1F *h1Hist_TWAvg_CUT[PLANES][21];                                                    //<------
   TH1F *h1Hist_TWDiffTrkPos[PLANES][21];             //1D hist of TW Corr. Dist - Track Position (width should be Hodo resolution)    <------
@@ -192,9 +271,9 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
 
   /*******Define Fit Functions and Related Variables*******/
 
-  Double_t Mean;                                      //variable to get Mean to make a 3sig cut
-  Double_t StdDev;                                    //variable to get satndar deviation to make a 3sig cut
-  Double_t nSig;                                         //multiple of Sigma used for sigmaCut
+  Double_t Mean;                                      //variable to get Mean to make a nSig*StdDev cut
+  Double_t StdDev;                                    //variable to get standard deviation to make a nSig*StdDev cut
+  Double_t nSig;                                      //multiple of Sigma used for sigmaCut
   
   //Gaussian Fit for TWAvg
   TF1 *gausFit[PLANES][21];
@@ -202,8 +281,21 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
   //1d Fit Function for fitting TW_Corr vs. TrkPos
   TF1 *fit1x = new TF1("fit1x", "[0]*x + [1]", -40., 40.);
   TF1 *fit1y = new TF1("fit1y", "[0]*x + [1]", -40., 40.);                                                                                                     
-  TF1 *fit2x = new TF1("fit2x", "[0]*x + [1]", -20., 40.);                                                                                 
-  TF1 *fit2y = new TF1("fit2y", "[0]*x + [1]", -20., 40.);                                                                             
+  TF1 *fit2x = new TF1("fit2x", "[0]*x + [1]", -40., 40.);                                                                                 
+  TF1 *fit2y = new TF1("fit2y", "[0]*x + [1]", -40., 40.);                                                                             
+
+  /*  ---- 1D Re-Fit Function ----
+     C. Yero Dec. 3 2021 | 1D Fit Function for re-fitting TW_Corr vs. TrkPos (in case fit failed or was out of velocity range)
+     This new fit function would be:  Y = m_fixed * X + b,  where m_fixed = 1 / phodo_velSet, and b is the y-intercept 
+     (cable time offset) which would be the ONLY fit parameter
+  */
+
+  TF1 *rfit1x = new TF1("rfit1x", Form("(1./%f) * x + [0]", phodo_velSet[0]), -40., 40.);
+  TF1 *rfit1y = new TF1("rfit1y", Form("(1./%f) * x + [0]", phodo_velSet[1]), -40., 40.);                                                                                                     
+  TF1 *rfit2x = new TF1("rfit2x", Form("(1./%f) * x + [0]", phodo_velSet[2]), -40., 40.);                                                                                 
+  TF1 *rfit2y = new TF1("rfit2y", Form("(1./%f) * x + [0]", phodo_velSet[3]), -40., 40.); 
+  
+
 
   //Set Param Values/Names
   fit1x->SetParameter(0, 1.), fit1x->SetParName(0, "slope");
@@ -214,6 +306,13 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
   fit2x->SetParameter(1, 1.), fit2x->SetParName(1, "y-int");  
   fit2y->SetParameter(0, 1.), fit2y->SetParName(0, "slope");           
   fit2y->SetParameter(1, 1.), fit2y->SetParName(1, "y-int"); 
+
+  //Set Param Values/Names for Re-Fit function
+  rfit1x->SetParameter(0, 1.), rfit1x->SetParName(0, "y-int");                                                                                                           
+  rfit1y->SetParameter(0, 1.), rfit1y->SetParName(0, "y-int");                                                                                                               
+  rfit2x->SetParameter(0, 1.), rfit2x->SetParName(0, "y-int");                                                                                                              
+  rfit2y->SetParameter(0, 1.), rfit2y->SetParName(0, "y-int");                                                                                                                                
+
   
   //Set PID 
   Bool_t pcal;
@@ -231,6 +330,9 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
   T->SetBranchAddress(npdc_ntrack, &pdc_ntrack);
   T->SetBranchAddress(nbeta, &beta);
 
+  // C.Y. Jan 23, 2022 | Added focal plane derivatives (dx/dz -> xp_fp, dy/dz -> yp_fp) used in beta calculation 'pathNorm' variable
+  T->SetBranchAddress(npdc_xpfp, &pdc_xpfp);
+  T->SetBranchAddress(npdc_ypfp, &pdc_ypfp);
  
   //Loop over hodo planes
   for (Int_t npl = 0; npl < PLANES; npl++ )
@@ -259,16 +361,16 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
 	       if (side==0) //require ONLY one side, since a time diff between two pmts at each end is taken
 		{
 
-		  h1Hist_TWAvg[npl][ipmt] = new TH1F(Form("Avg. Time: Paddle %s%d", pl_names[npl].c_str(), ipmt+1), Form("Paddle %s%d: Time-Walk Corrected Average Time", pl_names[npl].c_str(), ipmt+1), 100, 0, 100);
+		  h1Hist_TWAvg[npl][ipmt] = new TH1F(Form("Avg. Time: Paddle %s%d", pl_names[npl].c_str(), ipmt+1), Form("Paddle %s%d: Time-Walk Corrected Average Time", pl_names[npl].c_str(), ipmt+1), 200, 0, 200);
 		  
-		  h1Hist_TWAvg_CUT[npl][ipmt] = new TH1F(Form("Avg. Time CUT: Paddle %s%d", pl_names[npl].c_str(), ipmt+1), Form("Paddle %s%d: Time-Walk Corrected Average (CUT)",pl_names[npl].c_str(), ipmt+1), 100, 0, 100);
+		  h1Hist_TWAvg_CUT[npl][ipmt] = new TH1F(Form("Avg. Time CUT: Paddle %s%d", pl_names[npl].c_str(), ipmt+1), Form("Paddle %s%d: Time-Walk Corrected Average (CUT)",pl_names[npl].c_str(), ipmt+1), 200, 0, 200);
 	      
 		  h2Hist_TWDiff_v_TrkPos[npl][ipmt] = new TH2F(Form("DistDiff: Paddle %s%d", pl_names[npl].c_str(), ipmt+1), Form("Paddle %s%d: Time-Walk Corr. Hit Dist vs. Hod Track Position", pl_names[npl].c_str(), ipmt+1), 160, -80, 80, 200, -120, 80);
 		  h2Hist_TW_Corr_v_TrkPos[npl][ipmt] = new TH2F(Form("TimeDiff: Paddle %s%d", pl_names[npl].c_str(), ipmt+1), Form("Paddle %s%d: Time-Walk Corr. TimeDiff. vs. Hod Track Position", pl_names[npl].c_str(), ipmt+1), 160, -60, 60, 200, -15, 15);
 		  
 		  h1Hist_TWDiffTrkPos[npl][ipmt] = new TH1F(Form("DistDiff - Track: Paddle %s%d", pl_names[npl].c_str(), ipmt+1), Form("Paddle %s%d: Time-Walk Corr. Hit Dist. - Hod Track Position",pl_names[npl].c_str(), ipmt+1), 200, -120, 80);
 
-		  h2Hist_TWAvg_v_TrkPos[npl][ipmt] = new TH2F(Form("TimeAvg_v_Trk: Paddle %s%d", pl_names[npl].c_str(), ipmt+1), Form("Paddle %s%d: Time-Walk Corr. TimeAvg. vs. Hod Track Position", pl_names[npl].c_str(), ipmt+1), 160, -40, 40, 120, 0, 100);
+		  h2Hist_TWAvg_v_TrkPos[npl][ipmt] = new TH2F(Form("TimeAvg_v_Trk: Paddle %s%d", pl_names[npl].c_str(), ipmt+1), Form("Paddle %s%d: Time-Walk Corr. TimeAvg. vs. Hod Track Position", pl_names[npl].c_str(), ipmt+1), 160, -40, 40, 150, 0, 150);
   
 		  //Set Axis Titles
 		  h1Hist_TWAvg[npl][ipmt]->GetXaxis()->SetTitle("Time-Walk Corr. TDC Average Paddle Time (ns)");
@@ -297,12 +399,12 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
 	       
 	       
 	       //----Define TTree Leaf Names-----
-	       base = spec + "." + det + "." + pl_names[npl];
+	       base = spec + "." + det + "." + pl_names[npl].c_str();
 	       
-	       nTdcTimeUnCorr = base + "." + side_names[side] + "TdcTimeUnCorr";
-	       nTdcTimeTWCorr = base + "." + side_names[side] + "TdcTimeWalkCorr";
-	       nAdcPulseTime = base + "." + side_names[side] + "AdcPulseTime";
-	       nAdcPulseAmp = base + "." + side_names[side] + "AdcPulseAmp";
+	       nTdcTimeUnCorr = base + "." + side_names[side].c_str() + "TdcTimeUnCorr";
+	       nTdcTimeTWCorr = base + "." + side_names[side].c_str() + "TdcTimeWalkCorr";
+	       nAdcPulseTime = base + "." + side_names[side].c_str() + "AdcPulseTime";
+	       nAdcPulseAmp = base + "." + side_names[side].c_str() + "AdcPulseAmp";
 	       nDiffTWCorr = base + "." + "DiffDisTrackCorr";
 	       nTrackXPos = base + "." + "TrackXPos";
 	       nTrackYPos = base + "." + "TrackYPos";
@@ -313,10 +415,12 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
 	       T->SetBranchAddress(nTdcTimeTWCorr,  &TdcTimeTWCorr[npl][side]);
 	       T->SetBranchAddress(nAdcPulseTime,  &AdcPulseTime[npl][side]);
 	       T->SetBranchAddress(nAdcPulseAmp,  &AdcPulseAmp[npl][side]);
-	       T->SetBranchAddress(nDiffTWCorr,  &DiffDistTWCorr[npl]);
+	       //T->SetBranchAddress(nDiffTWCorr,  &DiffDistTWCorr[npl]);  //C.Y. Jan 04, 2021 | This needs to be re-calculated below using the updated hodo velocity/cable times from updated fits
 	       T->SetBranchAddress(nTrackXPos,  &TrackXPos[npl]);
 	       T->SetBranchAddress(nTrackYPos,  &TrackYPos[npl]);
 	       T->SetBranchAddress(nhod_nhits,  &hod_nhits[npl]);
+
+	       
 	       
 
 	    } //end loop over hodo PMTs
@@ -331,20 +435,34 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
   //**************************************************************//
   
   cout << "Initializing 1st Pass of Event Loop: " << endl;
-  Long64_t evtCnt = 0;
 
   Long64_t nentries = T->GetEntries();
+ 
+
+  // dynamically allocate 3d array
+  Bool_t ***mean_time_flg = new Bool_t **[nentries]();
   
- //Loop over all entries
+  for (int i = 0; i < nentries; i++) {
+    mean_time_flg[i] = new Bool_t *[PLANES]();
+    for (int j = 0; j < PLANES; j++){
+      mean_time_flg[i][j] = new Bool_t[21]();
+      for (int k = 0; k < 21; k++){
+	mean_time_flg[i][j][k] = false;
+      } // end k loop over paddles
+    } // end j loop over planes
+  } // end i loop over nentries
+
+
+  //Loop over all entries
   for(Long64_t i=0; i<nentries; i++)
     {
       T->GetEntry(i);  
-
+      
       pcal = pcal_etrkNorm>etrknrm_low_cut;
       pngcer = pngcer_npeSum>npngcer_npeSum_low_cut;
-      pdctrk = pdc_ntrack>0.0;
+      pdctrk = pdc_ntrack>0.0;  // Seems to work. One could potentially improve hit filtering further by requiring a single reconstructed track, but efficiency may suffer. 
       betaCut = beta>betanotrack_low_cut&& beta<betanotrack_hi_cut;
-        pid_pelec = pcal&&pngcer&&pdctrk;
+      pid_pelec = pcal&&pngcer&&pdctrk;
       if (cosmic_flag)  pid_pelec = betaCut&&pdctrk; 
        //Apply PID ELECTRON CUT
       if(pid_pelec)
@@ -358,7 +476,8 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
 	      for (Int_t ipmt = 0; ipmt < maxPMT[npl]; ipmt++)
 		{	        
 		  
-		  if(TdcTimeTWCorr[npl][0][ipmt] < 100. && TdcTimeTWCorr[npl][1][ipmt] < 100. && pcal_etrkNorm>0.7)
+		  //HARD CUT NOTICE		  
+		  if(TdcTimeTWCorr[npl][0][ipmt] < 200. && TdcTimeTWCorr[npl][1][ipmt] < 200. && pcal_etrkNorm>etrknrm_low_cut)
 		    {
 		      //Fill Average TW Corr TDC Time
 		      h1Hist_TWAvg[npl][ipmt]->Fill((TdcTimeTWCorr[npl][0][ipmt] + TdcTimeTWCorr[npl][1][ipmt])/2.);
@@ -370,132 +489,241 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
 	    }// end plane loop
 	  
 	} //END PID ELECTRON CUT
-
-      cout << std::setprecision(2) << double(i) / nentries * 100. << "  % " << std::flush << "\r";
-
-    } //end loop over entries
       
-      //Set cut on Sigma,
-      nSig = 1;    
-
-
+      cout << std::setprecision(2) << double(i) / nentries * 100. << "  % " << std::flush << "\r";
+      
+    } //end loop over entries
+  
+      //Set cut on StdDev. 
+      // Because of the small flat background of photon hits at high rates, a 1 StdDev cut ends up being generously wider than a Gaussian 1 sigma cut would be. 
+      // At very low rates (unlikely to be encountered in the SHMS) there may be some benefit in increasing nSig to 2 for higher efficiency. (This suggestion may be relevant to the HMS.)
+  //HARD CUT NOTICE
+  nSig = 1;    
+  
+  
   //************************************//
   //    SECOND PASS OF EVENT LOOP       //
   //************************************//
   cout << "Initializing 2nd Pass of Event Loop: " << endl;
-
+  
   //Loop over all entries
   for(Long64_t i=0; i<nentries; i++)
     {
       
       T->GetEntry(i);  
       
+      //initialize good paddle hit counter of hodo planes (resets per entry) 
+      good_hod_1x_nhits = 0;      
+      good_hod_1y_nhits = 0;
+      good_hod_2x_nhits = 0;
+      good_hod_2y_nhits = 0;
+      single_hit_flg = false;
+      
       pcal = pcal_etrkNorm>etrknrm_low_cut;
-      pngcer = pngcer_npeSum>npngcer_npeSum_low_cut;
-      pdctrk = pdc_ntrack>0.0;
+      pngcer = pngcer_npeSum>npngcer_npeSum_low_cut; //C.Y. Dec 12, 2021: put ONLY min cut requirement  |  JM 31-10-21: Added in npeSum > 0 requirement
+      pdctrk = pdc_ntrack>0.0;   // Seems to work. One could potentially improve hit filtering further by requiring a single reconstructed track, but efficiency may suffer. 
       betaCut = beta>betanotrack_low_cut&& beta<betanotrack_hi_cut;
       pid_pelec = pcal&&pngcer&&pdctrk;
       if (cosmic_flag)  pid_pelec = betaCut&&pdctrk; 
+      
+      
+      // ----------------- "LITE" HIT FILTERING (PART 1) -----------------
 
-
-      //-----APPLY PID CUT TO SELECT CLEAN ELECTRONS-----
-
-      if(pid_pelec)
-	{
-
-      //Loop over hodo planes
-      for (Int_t npl = 0; npl < PLANES; npl++ )
+      if(pid_pelec) // APPLY PID CUT TO SELECT CLEAN ELECTRONS
 	{
 	  
-	  //Loop over plane side
-	  for (Int_t side = 0; side < SIDES; side++)
+	  //Loop over hodo planes
+	  for (Int_t npl = 0; npl < PLANES; npl++ )
 	    {
 	      
-	      //Loop over pmt
-	      for (Int_t ipmt = 0; ipmt < maxPMT[npl]; ipmt++)
-		{	        
+	      //Loop over plane side
+	      for (Int_t side = 0; side < SIDES; side++)
+		{
 		  
-		  //Get Standard deviation from initial entry fill
-		  StdDev =  h1Hist_TWAvg[npl][ipmt]->GetStdDev();      
-		  Mean =  h1Hist_TWAvg[npl][ipmt]->GetMean();      
-		  
-		  //FIll Uncorrected/Corrected Time Walk Histos
-		  h2Hist_TW_UnCorr[npl][side][ipmt]->Fill(AdcPulseAmp[npl][side][ipmt], TdcTimeUnCorr[npl][side][ipmt] - AdcPulseTime[npl][side][ipmt] );
-		  h2Hist_TW_Corr[npl][side][ipmt]->Fill(AdcPulseAmp[npl][side][ipmt], TdcTimeTWCorr[npl][side][ipmt] - AdcPulseTime[npl][side][ipmt] );
-
-
-		  //Add Time Cuts to get rid of kBig - kBig values, which yielded high evt density at zero
-		  if(TdcTimeTWCorr[npl][0][ipmt] < 100. && TdcTimeTWCorr[npl][1][ipmt] < 100.)
-		    {
+		  //Loop over pmt
+		  for (Int_t ipmt = 0; ipmt < maxPMT[npl]; ipmt++)
+		    {	        
 		      
-		      if (side==0)  //require only one side, as a time diff between the two ends of a paddle is take
+		      //Get Standard deviation from initial entry fill
+		      StdDev =  h1Hist_TWAvg[npl][ipmt]->GetStdDev();      
+		      Mean =  h1Hist_TWAvg[npl][ipmt]->GetMean();      
+		  
+		      //FIll Uncorrected/Corrected Time Walk Histos
+		      h2Hist_TW_UnCorr[npl][side][ipmt]->Fill(AdcPulseAmp[npl][side][ipmt], TdcTimeUnCorr[npl][side][ipmt] - AdcPulseTime[npl][side][ipmt] );
+		      h2Hist_TW_Corr[npl][side][ipmt]->Fill(AdcPulseAmp[npl][side][ipmt], TdcTimeTWCorr[npl][side][ipmt] - AdcPulseTime[npl][side][ipmt] );
+		      
+		      
+		      //Add Time Cuts to get rid of kBig - kBig values, which yielded high evt density at zero
+		      //HARD CUT NOTICE
+		      if(TdcTimeTWCorr[npl][0][ipmt] < 200. && TdcTimeTWCorr[npl][1][ipmt] < 200.)
 			{
 			  
-			  
-			  if (npl==0 || npl==2)
+			  //require only one side, as a time diff between the two ends of a paddle is take
+			  if (side==0)  
 			    {
-			      h2Hist_TWAvg_v_TrkPos[npl][ipmt]->Fill(TrackYPos[npl], 0.5*(TdcTimeTWCorr[npl][1][ipmt] + TdcTimeTWCorr[npl][0][ipmt])); 
-			    }
-			  
-			  else if (npl==1 || npl==3)
-			    {
-			      h2Hist_TWAvg_v_TrkPos[npl][ipmt]->Fill(TrackXPos[npl], 0.5*(TdcTimeTWCorr[npl][1][ipmt] + TdcTimeTWCorr[npl][0][ipmt])); 
+			    
+			      // Apply mean tdc time +/- sig*StdDev cut to narrow window of "good hits"
+			      if ( (((TdcTimeTWCorr[npl][0][ipmt] + TdcTimeTWCorr[npl][1][ipmt])/2.) > (Mean-nSig*StdDev)) &&  (((TdcTimeTWCorr[npl][0][ipmt] + TdcTimeTWCorr[npl][1][ipmt])/2.) < (Mean+nSig*StdDev)))
+				{				  				  
+				  mean_time_flg[i][npl][ipmt] = true;
+				  
+				  // increment good plane hit counter 
+				  if(npl==0){				    
+				    good_hod_1x_nhits++;
+				   
+				  }
+				  if(npl==1){ 
+				    good_hod_1y_nhits++;
+				 
+				  }			    
+				  if(npl==2){              
+				    good_hod_2x_nhits++;
+				    
+				  }			      
+				  if(npl==3){            
+				    good_hod_2y_nhits++;				    
+				    
+				  }	        		    
+				  
+				} //end +-nSig*StdDev CUT of TW Corr Time
 			      
-			    }
-			  if ( (((TdcTimeTWCorr[npl][0][ipmt] + TdcTimeTWCorr[npl][1][ipmt])/2.) > (Mean-nSig*StdDev)) &&  (((TdcTimeTWCorr[npl][0][ipmt] + TdcTimeTWCorr[npl][1][ipmt])/2.) < (Mean+nSig*StdDev)))
+			    }//end single-side requirement
+			  
+			} //end time cuts
+		      
+		    }//end pmt loop
+		  
+		} //end side loop
+	      
+	    } //end plane loop
+	  
+	} //END PID ELECTRON
+      
+      cout << std::setprecision(2) << double(i) / nentries * 100. << "  % " << std::flush << "\r";
+      
+      
+      //Fill histogram of good hits per plane
+      H_good_hod1x_nhits->Fill(good_hod_1x_nhits);
+      H_good_hod1y_nhits->Fill(good_hod_1y_nhits); 
+      H_good_hod2x_nhits->Fill(good_hod_2x_nhits); 
+      H_good_hod2y_nhits->Fill(good_hod_2y_nhits); 
+     
+      //Define good plane hit
+      if( (good_hod_1x_nhits==1) && (good_hod_1y_nhits==1) && (good_hod_2x_nhits==1) && (good_hod_2y_nhits==1) ) { single_hit_flg = true; } 
+      
+      H_good_hod_nhits->Fill(single_hit_flg);
+      
+      //Fill branches with good hits per plane information
+      br_good_hod_1x_nhits->Fill();
+      br_good_hod_1y_nhits->Fill();
+      br_good_hod_2x_nhits->Fill();
+      br_good_hod_2y_nhits->Fill();
+      br_single_hit_flg->Fill();
+      
+      
+      // ----------------- "LITE" HIT FILTERING (PART 2) -----------------
+      if(pid_pelec && single_hit_flg)
+	{
+	  //Loop over hodo planes
+	  for (Int_t npl = 0; npl < PLANES; npl++ )
+	    {	      
+	      
+	      //Loop over plane side
+	      for (Int_t side = 0; side < SIDES; side++)
+		{
+		  
+		  //Loop over pmt
+		  for (Int_t ipmt = 0; ipmt < maxPMT[npl]; ipmt++)
+		    {	        
+		      if(mean_time_flg[i][npl][ipmt]==0) continue;  //C.Y. explicity add mean-time flag to eliminate possibility of multi-paddle hits per plane
+
+		      //Get Standard deviation from initial entry fill
+		      StdDev =  h1Hist_TWAvg[npl][ipmt]->GetStdDev();      
+		      Mean =  h1Hist_TWAvg[npl][ipmt]->GetMean();
+		      
+		      //Add Time Cuts to get rid of kBig - kBig values, which yielded high evt density at zero
+		      
+		      //HARD CUT NOTICE
+		      if(TdcTimeTWCorr[npl][0][ipmt] < 200. && TdcTimeTWCorr[npl][1][ipmt] < 200.)
+			{
+			  
+			  //require only one side, as a time diff between the two ends of a paddle is take
+			  if (side==0)  
 			    {
 			      
+
 			      if (npl==0 || npl==2)
 				{
-				  
-				  h2Hist_TW_Corr_v_TrkPos[npl][ipmt]->Fill(TrackYPos[npl],  0.5*(TdcTimeTWCorr[npl][1][ipmt] - TdcTimeTWCorr[npl][0][ipmt]));			      	
-				  h2Hist_TWDiff_v_TrkPos[npl][ipmt]->Fill(TrackYPos[npl],  DiffDistTWCorr[npl][ipmt]-TrackYPos[npl]);
-				  h1Hist_TWDiffTrkPos[npl][ipmt]->Fill(DiffDistTWCorr[npl][ipmt] - TrackYPos[npl]);                           
-				  phodo_sigArr[npl][ipmt] = h1Hist_TWDiffTrkPos[npl][ipmt]->GetStdDev();  //Get Paddle resolution stdDev to be used in sig. parameters
+				  h2Hist_TWAvg_v_TrkPos[npl][ipmt]->Fill(TrackYPos[npl], 0.5*(TdcTimeTWCorr[npl][1][ipmt] + TdcTimeTWCorr[npl][0][ipmt])); 
 				}
+			      
 			      else if (npl==1 || npl==3)
 				{
-				  
-				  h2Hist_TW_Corr_v_TrkPos[npl][ipmt]->Fill(TrackXPos[npl],  0.5*(TdcTimeTWCorr[npl][1][ipmt] - TdcTimeTWCorr[npl][0][ipmt]));
-				  h2Hist_TWDiff_v_TrkPos[npl][ipmt]->Fill(TrackXPos[npl],  DiffDistTWCorr[npl][ipmt]-TrackXPos[npl]);
-				  h1Hist_TWDiffTrkPos[npl][ipmt]->Fill(DiffDistTWCorr[npl][ipmt] - TrackXPos[npl]);                    
-				  phodo_sigArr[npl][ipmt] = h1Hist_TWDiffTrkPos[npl][ipmt]->GetStdDev();  //Get Paddle resolution stdDev to be used in sig. parameters
-
+				  h2Hist_TWAvg_v_TrkPos[npl][ipmt]->Fill(TrackXPos[npl], 0.5*(TdcTimeTWCorr[npl][1][ipmt] + TdcTimeTWCorr[npl][0][ipmt])); 
 				  
 				}
 			      
-			      h1Hist_TWAvg_CUT[npl][ipmt]->Fill((TdcTimeTWCorr[npl][0][ipmt] + TdcTimeTWCorr[npl][1][ipmt])/2.);
+			      // Apply mean tdc time +/- sig*StdDev cut to narrow window of "good hits"
+			      if ( (((TdcTimeTWCorr[npl][0][ipmt] + TdcTimeTWCorr[npl][1][ipmt])/2.) > (Mean-nSig*StdDev)) &&  (((TdcTimeTWCorr[npl][0][ipmt] + TdcTimeTWCorr[npl][1][ipmt])/2.) < (Mean+nSig*StdDev)))
+				{
+
+				  if (npl==0 || npl==2)
+				    {				      
+				      h2Hist_TW_Corr_v_TrkPos[npl][ipmt]->Fill(TrackYPos[npl],  0.5*(TdcTimeTWCorr[npl][1][ipmt] - TdcTimeTWCorr[npl][0][ipmt]));					     
+				    }
+				  
+				  else if (npl==1 || npl==3)
+				    {				      
+				      h2Hist_TW_Corr_v_TrkPos[npl][ipmt]->Fill(TrackXPos[npl],  0.5*(TdcTimeTWCorr[npl][1][ipmt] - TdcTimeTWCorr[npl][0][ipmt]));				      				      
+				    }
+				  
+				  h1Hist_TWAvg_CUT[npl][ipmt]->Fill((TdcTimeTWCorr[npl][0][ipmt] + TdcTimeTWCorr[npl][1][ipmt])/2.);
+				  
+				} //end meantime +/- nSig*StdDev CUT of TW Corr Time
 			      
-			    } //end 3SIGMA CUT of TW Corr Time
+			    } // end single-side requirement
 			  
-			}//end require ONLY single side
+			} //end time cuts
 		      
-		    } //end time cuts
+		    } //end pmt loop
 		  
-		}//end pmt loop
+		} //end side loop
 	      
-	    } //end side loop
+	    } //end plane loop
 	  
-	} //end plane loop
+	} // end pid-electron AND single plane hit CUTS (IMPORTANT ! ! ! )
       
-	} //END PID ELECTRON
-          
-      cout << std::setprecision(2) << double(i) / nentries * 100. << "  % " << std::flush << "\r";
-
     } //end entry loop
+  
+  //Draw good hits histograms per plane, and overall for 4 planes single hit.
+  good_hod1x_Hit_canv->cd();
+  H_good_hod1x_nhits->Draw();
 
-  cout << endl;
+  good_hod1y_Hit_canv->cd();
+  H_good_hod1y_nhits->Draw();  
 
+  good_hod2x_Hit_canv->cd();                                                                                                                                                  
+  H_good_hod2x_nhits->Draw();                                                                                                                                             
+
+  good_hod2y_Hit_canv->cd();                                                                                                                                                    
+  H_good_hod2y_nhits->Draw();                                                                                                                                             
+
+  good_hodSingleHit_canv->cd();
+  H_good_hod_nhits->Draw();
+  
+  
+  //The technique to fit the parameters phodo_velFit and phodo_cableFit is explained on page 4 and Figure 6 of the hodo calibration document v2 at https://hallcweb.jlab.org/doc-private/ShowDocument?docid=970 . 
+  
   cout << " Starting fitting slope and intercept of histograms" << endl;
-
-  /***********DRAW HISTOGRAMS TO CANVAS***************/
- for (Int_t npl = 0; npl < PLANES; npl++ )
+  
+  for (Int_t npl = 0; npl < PLANES; npl++ )
     {      
-    
-      //Create Canvas to store TW-Corr Time/Dist vs. trk position
+      
+      //--- Create Canvas to store TW-Corr Time/Dist vs. trk position ---
+      
       TWCorr_v_TrkPos_canv[npl] = new TCanvas(Form("TWCorrTime_v_Pos%d", npl), Form("2DTWCorr_Time, plane %s", pl_names[npl].c_str()),  1000, 700);
       TWDiff_v_TrkPos_canv[npl] = new TCanvas(Form("TWCorrDist_v_Pos%d", npl), Form("2DTWCorr_Dist, plane %s", pl_names[npl].c_str()),  1000, 700);
-
+      
       TWAvg_canv[npl] = new TCanvas(Form("TWAvg_%d", npl), Form("TWAvg, plane %s", pl_names[npl].c_str()),  1000, 700);
       TWAvg_canv_2D[npl] = new TCanvas(Form("TWAvg2D_%d", npl), Form("TWAvg2D, plane %s", pl_names[npl].c_str()),  1000, 700);
       Diff_TWDistTrkPos_canv[npl] = new TCanvas(Form("Diff_TrkDist_%d", npl), Form("Diff_TrkDist, plane %s", pl_names[npl].c_str()),  1000, 700);
@@ -507,7 +735,7 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
 	TWAvg_canv_2D[npl]->Divide(4,4);
 	Diff_TWDistTrkPos_canv[npl]->Divide(4,4);
       }
-     
+      
       else if (npl==3) {
 	TWCorr_v_TrkPos_canv[npl]->Divide(7,3);
 	TWDiff_v_TrkPos_canv[npl]->Divide(7,3);
@@ -532,17 +760,20 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
 	    TWUnCorr_canv[npl][side]->Divide(7,3);
 	    TWCorr_canv[npl][side]->Divide(7,3);
 	  }
+	  
 	  Int_t fit_status;
+	  
 	  //Loop over pmt
 	  for (Int_t ipmt = 0; ipmt < maxPMT[npl]; ipmt++)
 	    {	        
 	     
 	      TWUnCorr_canv[npl][side]->cd(ipmt+1);
 	      h2Hist_TW_UnCorr[npl][side][ipmt]->Draw("colz");
-	      	 
+	      
 	      TWCorr_canv[npl][side]->cd(ipmt+1);
 	      h2Hist_TW_Corr[npl][side][ipmt]->Draw("colz");
 	      fit_status=-1;
+	      
 	      //Require ONLY one side
 	      if (side==0)
 		{
@@ -553,7 +784,8 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
 		  //Fit TW Corr Time vs. Trk Pos
 		  if (npl==0)
 		    {
-		      fit_status = h2Hist_TW_Corr_v_TrkPos[npl][ipmt]->Fit("fit1x", "QR");  		    }
+		      fit_status = h2Hist_TW_Corr_v_TrkPos[npl][ipmt]->Fit("fit1x", "QR");
+		    }
 		  else if (npl==1)
 		    {   
 		      fit_status =  h2Hist_TW_Corr_v_TrkPos[npl][ipmt]->Fit("fit1y", "QR");     
@@ -566,10 +798,7 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
 		    {                                                                                            
                       fit_status = h2Hist_TW_Corr_v_TrkPos[npl][ipmt]->Fit("fit2y", "QR");     
 		    } 
-		  		  
-		  TWDiff_v_TrkPos_canv[npl]->cd(ipmt+1);
-		  h2Hist_TWDiff_v_TrkPos[npl][ipmt]->Draw("colz");
-		  
+
 		  TWAvg_canv_2D[npl]->cd(ipmt+1);
 		  h2Hist_TWAvg_v_TrkPos[npl][ipmt]->Draw("colz");
 		  
@@ -579,59 +808,283 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
 		  h1Hist_TWAvg_CUT[npl][ipmt]->SetLineColor(kRed);
 		  h1Hist_TWAvg[npl][ipmt]->Draw();
 		  h1Hist_TWAvg_CUT[npl][ipmt]->Draw("same");
-		  
-		  Diff_TWDistTrkPos_canv[npl]->cd(ipmt+1);
-		  h1Hist_TWDiffTrkPos[npl][ipmt]->Draw();
-				  	  
+		  		  	  
 		  if (npl==0) {
-		    phodo_velArr[0][ipmt] = 1./(fit1x->GetParameter(0));
-		    if(fit_status==-1 || phodo_velArr[0][ipmt]==1 ) {
-                           phodo_velArr[0][ipmt] = 15.0;
-                           phodo_cableArr[0][ipmt] = 0.0;
-                           phodo_sigArr[0][ipmt] = 1.0;
-			   cout << " Could not fit plane = " << npl << " paddle = " << ipmt +1 << endl;
-                    } else {
-		           phodo_cableArr[0][ipmt] = fit1x->GetParameter(1);
-		           phodo_sigArr[0][ipmt] = phodo_sigArr[0][ipmt] / (2.*phodo_velArr[0][ipmt]);
-		    }
+		    phodo_velArr[npl][ipmt] = 1./(fit1x->GetParameter(0));
+
+		    //C. Yero Nov 09, 2021  | Added Min/Max velocity constraints
+		    // (if fit failed "OR" if fit velocity is out-of-range)
+		    if(fit_status==-1 || (phodo_velArr[npl][ipmt] < phodo_velMin[npl] || phodo_velArr[npl][ipmt] > phodo_velMax[npl]) ) {
+		      
+		      
+		      if(phodo_velArr[npl][ipmt] < phodo_velMin[npl] || phodo_velArr[npl][ipmt] > phodo_velMax[npl]) { 
+			cout << Form("PLANE 1X, PADDLE %d : fit velocity, %.3f cm/ns is out-of-range [%.3f, %.3f] cm/ns ", (ipmt+1), phodo_velArr[npl][ipmt], phodo_velMin[npl], phodo_velMax[npl] ) << endl;
+			cout <<    "***********************" << endl;
+			cout << "" << endl;
+			cout << Form("---- PLANE 1X, PADDLE %d : ORIGINAL FIT RESULTS ----", ipmt+1) << endl;                                                                                                                               
+			cout << Form("phodo_velocity (1/fit_slope) = %.3f ", phodo_velArr[npl][ipmt]) << endl;                                                                                                                     
+			cout << Form("phodo_cable_offset (y-int.) = %.3f", fit1x->GetParameter(1)) << endl;                                                                                                                                                
+			cout << "-------------------------------" << endl;   
+			cout << "" << endl;
+			cout << Form(" Will try re-fitting line with fit function: Y = 1 / (%.3f cm/ns) * X + b", phodo_velSet[npl] ) << endl;
+			cout << "" << endl;
+		      }
+		      else if (fit_status==-1){
+			cout << "FIT FAILED FOR . . . " << endl;
+			cout << Form("PLANE 1X, PADDLE %d : fit velocity, %.3f cm/ns  ", (ipmt+1), phodo_velArr[npl][ipmt] ) << endl;
+			cout << Form(" Will try re-fitting line with fit function: Y = 1 / (%.3f cm/ns) * X + b", phodo_velSet[npl] ) << endl;  
+			cout << "" << endl;  
+		      }
+		      
+		      //Re-Fit TW Corr Time vs. Trk Pos		   
+		      fit_status = h2Hist_TW_Corr_v_TrkPos[npl][ipmt]->Fit("rfit1x", "QR+");  // The '+' is to overlay fit with previous original fit
+		      rfit1x->SetLineColor(kBlack);
+		      rfit1x->SetLineStyle(9);
+		      
+		      cout << Form("---- PLANE 1X, PADDLE %d : RE-FIT RESULTS ----", ipmt+1) << endl;
+		      cout << Form("phodo_velocity (1/fit_slope) = %.3f ", phodo_velSet[npl]) << endl;
+		      cout << Form("phodo_cable_offset (y-int.) = %.3f", rfit1x->GetParameter(0)) << endl;
+		      cout << "-------------------------------" << endl;  
+		      cout << "" << endl;
+		      
+		      TWDiff_v_TrkPos_canv[npl]->cd(ipmt+1);
+		      rfit1x->Draw();
+		            		      
+		      //Set the re-fit results parameter values
+		      phodo_velArr[npl][ipmt] = phodo_velSet[npl];
+		      phodo_cableArr[npl][ipmt] = rfit1x->GetParameter(0);
+		      //phodo_sigArr[npl][ipmt] = phodo_sigArr[npl][ipmt] / (2.*phodo_velSet[npl]);  Jan 04, 2021 (will be re-calculated in Hit Filtering Part 3)
+		      
+		      //Check fit status of re-fit 
+		      if(fit_status==-1) // fit failed a second time (most likely empy data histo, or non-operational channel)
+			{
+			  phodo_velArr[npl][ipmt] = phodo_velSet[npl];                             
+			  phodo_cableArr[npl][ipmt] = 0.0;                                                           
+			  phodo_sigArr[npl][ipmt] = 1.0;  
+			}
+		    }		    
+		    
+		    // if fit is good (i.e., within range)
+		    else {
+		      
+		      cout << "" << endl;
+		      cout << Form("---- PLANE 1X, PADDLE %d : VALID FIT RESULTS ----", ipmt+1) << endl;                                                                                            
+                      cout << Form("phodo_velocity (1/fit_slope) = %.3f cm/ns", phodo_velArr[0][ipmt]) << endl;    
+		      cout << Form("phodo_cable_offset (y-int.) = %.3f ns", fit1x->GetParameter(1)) << endl; 
+		      cout << "-------------------------------" << endl;
+		      cout << "" << endl;
+		      
+		      phodo_cableArr[0][ipmt] = fit1x->GetParameter(1);
+		      //phodo_sigArr[0][ipmt] = phodo_sigArr[0][ipmt] / (2.*phodo_velArr[0][ipmt]); Jan 04, 2021 (will be re-calculated in Hit Filtering Part 3)
+		    }		  		  
 		  }
 		  
 		  else if (npl==1) { 
-		    phodo_velArr[1][ipmt] = 1./(fit1y->GetParameter(0)); 
-		    if(fit_status==-1|| phodo_velArr[1][ipmt]==1) {
-                           phodo_velArr[1][ipmt] = 15.0;
-                           phodo_cableArr[1][ipmt] = 0.0;
-                           phodo_sigArr[1][ipmt] = 1.0;
-			   cout << " Could not fit plane = " << npl << " paddle = " << ipmt +1 << endl;
-                    } else {
-		           phodo_cableArr[1][ipmt] = fit1y->GetParameter(1);
-		           phodo_sigArr[1][ipmt] = phodo_sigArr[1][ipmt] / (2.*phodo_velArr[1][ipmt]);
+		    phodo_velArr[npl][ipmt] = 1./(fit1y->GetParameter(0)); 
+		    
+		    if(fit_status==-1 || (phodo_velArr[npl][ipmt] < phodo_velMin[npl] || phodo_velArr[npl][ipmt] > phodo_velMax[npl]) ) {
+		      
+		      if (phodo_velArr[npl][ipmt] < phodo_velMin[npl] || phodo_velArr[npl][ipmt] > phodo_velMax[npl]){
+			cout << Form("PLANE 1Y, PADDLE %d : fit velocity, %.3f cm/ns is out-of-range [%.3f, %.3f] cm/ns ", (ipmt+1), phodo_velArr[npl][ipmt], phodo_velMin[npl], phodo_velMax[npl] ) << endl;
+			cout <<    "***********************" << endl;
+			cout << "" << endl;
+			cout << Form("---- PLANE 1Y, PADDLE %d : ORIGINAL FIT RESULTS ----", ipmt+1) << endl;                                                                                                                               
+			cout << Form("phodo_velocity (1/fit_slope) = %.3f ", phodo_velArr[npl][ipmt]) << endl;                                                                                                                     
+			cout << Form("phodo_cable_offset (y-int.) = %.3f", fit1y->GetParameter(1)) << endl;                                                                                                                                                
+			cout << "-------------------------------" << endl;   
+			cout << "" << endl;
+			cout << Form(" Will try re-fitting line with fit function: Y = 1 / (%.3f cm/ns) * X + b", phodo_velSet[npl] ) << endl;
+			cout << "" << endl;
+		      }
+		      else if (fit_status==-1){                                                                                                
+                        cout << "FIT FAILED FOR . . . " << endl;                                                                                                          
+                        cout << Form("PLANE 1Y, PADDLE %d : fit velocity, %.3f cm/ns  ", (ipmt+1), phodo_velArr[npl][ipmt] ) << endl;                                     
+                        cout << Form(" Will try re-fitting line with fit function: Y = 1 / (%.3f cm/ns) * X + b", phodo_velSet[npl] ) << endl;                                                
+                        cout << "" << endl;                                                                                                                                                 
+                      }  
+
+		      //Re-Fit TW Corr Time vs. Trk Pos		   
+		      fit_status = h2Hist_TW_Corr_v_TrkPos[npl][ipmt]->Fit("rfit1y", "QR+");
+		      rfit1y->SetLineColor(kBlack);
+		      rfit1y->SetLineStyle(9);
+		      
+		      cout << Form("---- PLANE 1Y, PADDLE %d : RE-FIT RESULTS ----", ipmt+1) << endl;
+		      cout << Form("phodo_velocity (1/fit_slope) = %.3f ", phodo_velSet[npl]) << endl;
+		      cout << Form("phodo_cable_offset (y-int.) = %.3f", rfit1y->GetParameter(0)) << endl;
+		      cout << "-------------------------------" << endl;  
+		      cout << "" << endl;
+		      
+		      TWDiff_v_TrkPos_canv[npl]->cd(ipmt+1);
+		      rfit1y->Draw();
+		            		      
+		      //Set the parameter values
+		      phodo_velArr[npl][ipmt] = phodo_velSet[npl];
+		      phodo_cableArr[npl][ipmt] = rfit1y->GetParameter(0) ;
+		      //phodo_sigArr[npl][ipmt] = phodo_sigArr[npl][ipmt] / (2.*phodo_velSet[npl]); Jan 04, 2021 (will be re-calculated in Hit Filtering Part 3)
+		      
+		      //Check fit status of re-fit                                                                                
+                      if(fit_status==-1) // fit failed a second time (most likely empy data histo, or non-operational channel)      
+                        {                                                                                                           
+                          phodo_velArr[npl][ipmt] = phodo_velSet[npl];                                                             
+                          phodo_cableArr[npl][ipmt] = 0.0;                                                                          
+                          phodo_sigArr[npl][ipmt] = 1.0;                                                                                 
+                        } 
+
+		    }		    
+		    
+		    else {
+
+		      cout << "" << endl;
+		      cout << Form("---- PLANE 1Y, PADDLE %d : VALID FIT RESULTS ----", ipmt+1) << endl;                                                                                            
+                      cout << Form("phodo_velocity (1/fit_slope) = %.3f cm/ns", phodo_velArr[npl][ipmt]) << endl;    
+		      cout << Form("phodo_cable_offset (y-int.) = %.3f ns", fit1y->GetParameter(1)) << endl; 
+		      cout << "-------------------------------" << endl;
+		      cout << "" << endl;
+		      
+		      phodo_cableArr[npl][ipmt] = fit1y->GetParameter(1);
+		      //phodo_sigArr[npl][ipmt] = phodo_sigArr[npl][ipmt] / (2.*phodo_velArr[npl][ipmt]); Jan 04, 2021 (will be re-calculated in Hit Filtering Part 3)
 		    }
+
 		  }
-		  else if (npl==2) { 
-		    phodo_velArr[2][ipmt] = 1./(fit2x->GetParameter(0)); 
-		    if(fit_status==-1 || phodo_velArr[2][ipmt]==1) {
-                          phodo_velArr[2][ipmt] = 15.0;
-                           phodo_cableArr[2][ipmt] = 0.0;
-                           phodo_sigArr[2][ipmt] = 1.0;
-			   cout << " Could not fit plane = " << npl << " paddle = " << ipmt +1 << endl;
-                    } else {
-		    phodo_cableArr[2][ipmt] = fit2x->GetParameter(1);
-		    phodo_sigArr[2][ipmt] = phodo_sigArr[2][ipmt] / (2.*phodo_velArr[2][ipmt]);
+
+		  
+		  else if (npl==2) {
+		    
+		    phodo_velArr[npl][ipmt] = 1./(fit2x->GetParameter(0)); 
+
+		     if(fit_status==-1 || (phodo_velArr[npl][ipmt] < phodo_velMin[npl] || phodo_velArr[npl][ipmt] > phodo_velMax[npl]) ) {
+		      
+		       if(phodo_velArr[npl][ipmt] < phodo_velMin[npl] || phodo_velArr[npl][ipmt] > phodo_velMax[npl]) {
+			 cout << Form("PLANE 2X, PADDLE %d : fit velocity, %.3f cm/ns is out-of-range [%.3f, %.3f] cm/ns ", (ipmt+1), phodo_velArr[npl][ipmt], phodo_velMin[npl], phodo_velMax[npl] ) << endl;
+			 cout <<    "***********************" << endl;
+			 cout << "" << endl;
+			 cout << Form("---- PLANE 2X, PADDLE %d : ORIGINAL FIT RESULTS ----", ipmt+1) << endl;                                                                                                                               
+			 cout << Form("phodo_velocity (1/fit_slope) = %.3f ", phodo_velArr[npl][ipmt]) << endl;                                                                                                                     
+			 cout << Form("phodo_cable_offset (y-int.) = %.3f", fit2x->GetParameter(1)) << endl;                                                                                                                                                
+			 cout << "-------------------------------" << endl;   
+			 cout << "" << endl;
+			 cout << Form(" Will try re-fitting line with fit function: Y = 1 / (%.3f cm/ns) * X + b", phodo_velSet[npl] ) << endl;
+			 cout << "" << endl;
+		       }
+		       else if (fit_status==-1){    
+			 cout << "FIT FAILED FOR . . . " << endl;                                                              
+			 cout << Form("PLANE 2X, PADDLE %d : fit velocity, %.3f cm/ns  ", (ipmt+1), phodo_velArr[npl][ipmt] ) << endl;                                 
+			 cout << Form(" Will try re-fitting line with fit function: Y = 1 / (%.3f cm/ns) * X + b", phodo_velSet[npl] ) << endl;                    
+			 cout << "" << endl;                                                                                                                                 
+		       }  
+		       
+		       //Re-Fit TW Corr Time vs. Trk Pos		   
+		       fit_status = h2Hist_TW_Corr_v_TrkPos[npl][ipmt]->Fit("rfit2x", "QR+");
+		       rfit2x->SetLineColor(kBlack);
+		       rfit2x->SetLineStyle(9);
+		      
+		      cout << Form("---- PLANE 2X, PADDLE %d : RE-FIT RESULTS ----", ipmt+1) << endl;
+		      cout << Form("phodo_velocity (1/fit_slope) = %.3f ", phodo_velSet[npl]) << endl;
+		      cout << Form("phodo_cable_offset (y-int.) = %.3f", rfit2x->GetParameter(0)) << endl;
+		      cout << "-------------------------------" << endl;  
+		      cout << "" << endl;
+		      
+		      TWDiff_v_TrkPos_canv[npl]->cd(ipmt+1);
+		      rfit2x->Draw();
+		            		      
+		      //Set the parameter values
+		      phodo_velArr[npl][ipmt] = phodo_velSet[npl];
+		      phodo_cableArr[npl][ipmt] = rfit2x->GetParameter(0) ;
+		      //phodo_sigArr[npl][ipmt] = phodo_sigArr[npl][ipmt] / (2.*phodo_velSet[npl]); Jan 04, 2021 (will be re-calculated in Hit Filtering Part 3)
+
+		      //Check fit status of re-fit                                                                                     
+                      if(fit_status==-1) // fit failed a second time (most likely empy data histo, or non-operational channel)     
+                        {                                                                                                         
+                          phodo_velArr[npl][ipmt] = phodo_velSet[npl];                                                         
+                          phodo_cableArr[npl][ipmt] = 0.0;                                                                          
+                          phodo_sigArr[npl][ipmt] = 1.0;                                                                              
+                        } 
+		      
+		     }		    
+		    		    
+		    else {
+		      cout << Form("---- PLANE 2X, PADDLE %d : VALID FIT RESULTS ----", ipmt+1) << endl;           
+                      cout << Form("phodo_velocity (1/fit_slope) = %.3f cm/ns", phodo_velArr[npl][ipmt]) << endl;    
+		      cout << Form("phodo_cable_offset (y-int.) = %.3f ns", fit2x->GetParameter(1)) << endl; 
+		      cout << "-------------------------------" << endl;
+		      cout << "" << endl;
+		      
+		    phodo_cableArr[npl][ipmt] = fit2x->GetParameter(1);
+		    //phodo_sigArr[npl][ipmt] = phodo_sigArr[npl][ipmt] / (2.*phodo_velArr[npl][ipmt]); Jan 04, 2021 (will be re-calculated in Hit Filtering Part 3)
+
+		    }		     
+
+		  }
+		  
+		  else if (npl==3) {
+		    
+		    phodo_velArr[npl][ipmt] = 1./(fit2y->GetParameter(0));
+		    
+		    if(fit_status==-1 || (phodo_velArr[npl][ipmt] < phodo_velMin[npl] || phodo_velArr[npl][ipmt] > phodo_velMax[npl]) ) {
+		      
+		      if(phodo_velArr[npl][ipmt] < phodo_velMin[npl] || phodo_velArr[npl][ipmt] > phodo_velMax[npl]){
+			cout << Form("PLANE 2Y, PADDLE %d : fit velocity, %.3f cm/ns is out-of-range [%.3f, %.3f] cm/ns ", (ipmt+1), phodo_velArr[npl][ipmt], phodo_velMin[npl], phodo_velMax[npl] ) << endl;
+			cout <<    "***********************" << endl;
+			cout << "" << endl;
+			cout << Form("---- PLANE 2Y, PADDLE %d : ORIGINAL FIT RESULTS ----", ipmt+1) << endl;                                                                             
+			cout << Form("phodo_velocity (1/fit_slope) = %.3f ", phodo_velArr[npl][ipmt]) << endl;                                                                                    
+			cout << Form("phodo_cable_offset (y-int.) = %.3f", fit2y->GetParameter(1)) << endl;           
+			cout << "-------------------------------" << endl;   
+			cout << "" << endl;
+			cout << Form(" Will try re-fitting line with fit function: Y = 1 / (%.3f cm/ns) * X + b", phodo_velSet[npl] ) << endl;
+			cout << "" << endl;
+		      }
+
+		      else if (fit_status==-1){                                                                                                                                                              
+			cout << "FIT FAILED FOR . . . " << endl;                                                                                                                                             
+			cout << Form("PLANE 2Y, PADDLE %d : fit velocity, %.3f cm/ns  ", (ipmt+1), phodo_velArr[npl][ipmt] ) << endl;                                                                        
+			cout << Form(" Will try re-fitting line with fit function: Y = 1 / (%.3f cm/ns) * X + b", phodo_velSet[npl] ) << endl;                                                               
+			cout << "" << endl;                                                                                                                                                                  
+		      } 
+
+		      //Re-Fit TW Corr Time vs. Trk Pos		   
+		      fit_status = h2Hist_TW_Corr_v_TrkPos[npl][ipmt]->Fit("rfit2y", "QR+");
+		      rfit2y->SetLineColor(kBlack);
+		      rfit2y->SetLineStyle(9);
+		      
+		      cout << Form("---- PLANE 2Y, PADDLE %d : RE-FIT RESULTS ----", ipmt+1) << endl;
+		      cout << Form("phodo_velocity (1/fit_slope) = %.3f ", phodo_velSet[npl]) << endl;
+		      cout << Form("phodo_cable_offset (y-int.) = %.3f", rfit2y->GetParameter(0)) << endl;
+		      cout << "-------------------------------" << endl;  
+		      cout << "" << endl;
+		      
+		      TWDiff_v_TrkPos_canv[npl]->cd(ipmt+1);
+		      rfit2y->Draw();
+		            		      
+		      //Set the parameter values
+		      phodo_velArr[npl][ipmt] = phodo_velSet[npl];
+		      phodo_cableArr[npl][ipmt] = rfit2y->GetParameter(0) ;
+		      //phodo_sigArr[npl][ipmt] = phodo_sigArr[npl][ipmt] / (2.*phodo_velSet[npl]); Jan 04, 2021 (will be re-calculated in Hit Filtering Part 3)
+		      
+		      //Check fit status of re-fit                                           
+                      if(fit_status==-1) // fit failed a second time (most likely empy data histo, or non-operational channel)          
+                        {                                                                                                             
+                          phodo_velArr[npl][ipmt] = phodo_velSet[npl];                                   
+                          phodo_cableArr[npl][ipmt] = 0.0;                                                                               
+                          phodo_sigArr[npl][ipmt] = 1.0;                                                                              
+                        } 
+		    
 		    }
-		  }
-		  else if (npl==3) { 
-		    phodo_velArr[3][ipmt] = 1./(fit2y->GetParameter(0));
-		    if(fit_status==-1 || phodo_velArr[3][ipmt]==1) {
-                           phodo_velArr[3][ipmt] = 15.0;
-                           phodo_cableArr[3][ipmt] = 0.0;
-                           phodo_sigArr[3][ipmt] = 1.0;
-			   cout << " Could not fit plane = " << npl << " paddle = " << ipmt +1 << endl;
-                    } else {
-		         phodo_cableArr[3][ipmt] = fit2y->GetParameter(1);
-		         phodo_sigArr[3][ipmt] = phodo_sigArr[3][ipmt] / (2.*phodo_velArr[3][ipmt]);
+		    
+		    else {	
+		      cout << Form("---- PLANE 2Y, PADDLE %d : VALID FIT RESULTS ----", ipmt+1) << endl;                            
+		      cout << Form("phodo_velocity (1/fit_slope) = %.3f cm/ns", phodo_velArr[npl][ipmt]) << endl;    
+		      cout << Form("phodo_cable_offset (y-int.) = %.3f ns", fit2y->GetParameter(1)) << endl; 
+		      cout << "-------------------------------" << endl;
+		      cout << "" << endl;
+		      
+		      phodo_cableArr[npl][ipmt] = fit2y->GetParameter(1);
+		      //phodo_sigArr[npl][ipmt] = phodo_sigArr[npl][ipmt] / (2.*phodo_velArr[npl][ipmt]); Jan 04, 2021 (will be re-calculated in Hit Filtering Part 3)
+		      
 		    }
+		    
 		  }
+		  
 	
 		} //end single SIDE requirement
 	      
@@ -640,8 +1093,130 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
 	} //end side loop
   
     } //end plane loop
+ 
 
 
+
+ //************************************//
+ //    THIRD PASS OF EVENT LOOP       //
+ //************************************//
+  cout << "Initializing 3rd Pass of Event Loop: " << endl;
+
+  //Loop over all entries
+  for(Long64_t i=0; i<nentries; i++)
+    {
+      
+      T->GetEntry(i);  
+
+      pcal = pcal_etrkNorm>etrknrm_low_cut;
+      pngcer = pngcer_npeSum>npngcer_npeSum_low_cut; //C.Y. Dec 12, 2021: put ONLY min cut requirement  |  JM 31-10-21: Added in npeSum > 0 requirement
+      pdctrk = pdc_ntrack>0.0;   // Seems to work. One could potentially improve hit filtering further by requiring a single reconstructed track, but efficiency may suffer. 
+      betaCut = beta>betanotrack_low_cut&& beta<betanotrack_hi_cut;
+      pid_pelec = pcal&&pngcer&&pdctrk;
+      
+      if (cosmic_flag)  pid_pelec = betaCut&&pdctrk;
+      
+      // ----------------- "LITE" HIT FILTERING (PART 3) -----------------
+
+      if(pid_pelec && single_hit_flg) // per entry: apply PID cut AND single-hit requirement TO SELECT CLEAN ELECTRONS
+	{
+	  
+	  //Loop over hodo planes
+	  for (Int_t npl = 0; npl < PLANES; npl++ )
+	    {
+	      
+	   
+	      //Loop over plane side
+	      for (Int_t side = 0; side < SIDES; side++)
+		{
+		  
+		  //Loop over pmt
+		  for (Int_t ipmt = 0; ipmt < maxPMT[npl]; ipmt++)
+		    {	        
+		      
+		      if(mean_time_flg[i][npl][ipmt]==0) continue; 
+
+		      //Get Standard deviation from initial entry fill
+		      StdDev =  h1Hist_TWAvg[npl][ipmt]->GetStdDev();      
+		      Mean =  h1Hist_TWAvg[npl][ipmt]->GetMean();      
+
+		      //Add Time Cuts to get rid of kBig - kBig values, which yielded high evt density at zero
+//HARD CUT NOTICE
+		      if(TdcTimeTWCorr[npl][0][ipmt] < 200. && TdcTimeTWCorr[npl][1][ipmt] < 200.)
+			{
+			  
+			  //require only one side, as a time diff between the two ends of a paddle is taken
+			  if (side==0)  
+			    {
+
+			        // Apply mean tdc time +/- nsig*StdDev cut to narrow window of "good hits"
+			      if ( (((TdcTimeTWCorr[npl][0][ipmt] + TdcTimeTWCorr[npl][1][ipmt])/2.) > (Mean-nSig*StdDev)) &&  (((TdcTimeTWCorr[npl][0][ipmt] + TdcTimeTWCorr[npl][1][ipmt])/2.) < (Mean+nSig*StdDev)))
+				{
+
+				  if (npl==0 || npl==2)
+				    {
+				      //C.Y. Jan 04, 2021 | Calculate Minty Fresh DiffDistTWCorr (using the update parameters from the velocity fits done earlier in this code) 
+				      DiffDistTWCorr[npl][ipmt] = phodo_velArr[npl][ipmt] * 0.5 * (TdcTimeTWCorr[npl][1][ipmt] - 2*phodo_cableArr[npl][ipmt] - TdcTimeTWCorr[npl][0][ipmt]);
+				      h2Hist_TWDiff_v_TrkPos[npl][ipmt]->Fill(TrackYPos[npl],  DiffDistTWCorr[npl][ipmt]-TrackYPos[npl]);
+				      h1Hist_TWDiffTrkPos[npl][ipmt]->Fill(DiffDistTWCorr[npl][ipmt] - TrackYPos[npl]);                           
+
+				    }
+				  else if (npl==1 || npl==3)
+				    {
+				      //C.Y. Jan 04, 2021 | Calculate Minty Fresh DiffDistTWCorr (using the update parameters from the velocity fits done earlier in this code) 
+				      DiffDistTWCorr[npl][ipmt] = phodo_velArr[npl][ipmt] * 0.5 * (TdcTimeTWCorr[npl][1][ipmt] - 2*phodo_cableArr[npl][ipmt] - TdcTimeTWCorr[npl][0][ipmt]);
+				      h2Hist_TWDiff_v_TrkPos[npl][ipmt]->Fill(TrackXPos[npl],  DiffDistTWCorr[npl][ipmt]-TrackXPos[npl]);
+				      h1Hist_TWDiffTrkPos[npl][ipmt]->Fill(DiffDistTWCorr[npl][ipmt] - TrackXPos[npl]);                    
+
+				    }
+				  
+				} // //end meantime +/- nSig*StdDev CUT of TW Corr Time
+
+			      
+			    } //end single-side requirement
+
+			} //end time cuts
+
+		    } //end pmt loop
+
+		} //end side loop
+
+	    } //end plane loop
+
+	} // end pid-electron AND single plane hit CUTS (IMPORTANT ! ! ! )
+
+       cout << std::setprecision(2) << double(i) / nentries * 100. << "  % " << std::flush << "\r";
+       
+    } //end entry loop
+
+  // ---- Calculate updated hodoscope sigma parameters ----
+
+  //Loop over hodo planes
+  for (Int_t npl = 0; npl < PLANES; npl++ )
+    {
+      //NOTE: no side requirement, as this parameter is per paddle (not pmt side)
+      
+      //Loop over pmt
+      for (Int_t ipmt = 0; ipmt < maxPMT[npl]; ipmt++)
+	{	        
+
+	  // Calculate updated hodoscope sigma parameters
+	  phodo_sigArr[npl][ipmt] = h1Hist_TWDiffTrkPos[npl][ipmt]->GetStdDev();
+	  phodo_sigArr[npl][ipmt] = phodo_sigArr[npl][ipmt] / (2.*phodo_velArr[npl][ipmt]);	  
+
+	  // Draw remaining histograms dependent on the calculated 'DiffDistTWCorr' variable
+	  TWDiff_v_TrkPos_canv[npl]->cd(ipmt+1);
+	  h2Hist_TWDiff_v_TrkPos[npl][ipmt]->Draw("colz");  
+
+	  Diff_TWDistTrkPos_canv[npl]->cd(ipmt+1);
+	  h1Hist_TWDiffTrkPos[npl][ipmt]->Draw();
+
+	}
+    }
+
+
+  //-----------------------
+ 
  /************WRITE FIT RESULTS TO PARAMETER FILE***************/
  
  ofstream outPARAM;
@@ -716,19 +1291,28 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
      outPARAM << setw(26) << phodo_sigArr[0][ipmt] << ", " << setw(15) << phodo_sigArr[1][ipmt] << ", " << setw(15) << phodo_sigArr[2][ipmt] << ", " << setw(15) << phodo_sigArr[3][ipmt] << fixed << endl; 
    }
  }
- //Write Histograms to ROOT file
- outROOT->Write();
- outROOT->Close();
+ 
    
  cout << "FINISHED Getting Vp and Cable Fits . . . " << endl;
  cout << "Starting the code to fit Hodo Matrix . . . " << endl;                                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
- /**********BEGIN CODE TO FIT HODO MATRIX**************/
+ /**********BEGIN CODE TO FIT TIMING CORRECTIONS PER PADDLE, the phodo_LCoeff PARAMETERS**************/
+// These are the time offsets associated with the meantime of the pos and neg TDCs of a paddle. 
+// The technique to determine these parameters is explained on pages 5-7 of the hodo calibration document v2 at https://hallcweb.jlab.org/doc-private/ShowDocument?docid=970 . 
+// The hodo hit filtering in this section has not been updated but is clean. However, the efficiency may be low depending on how wide the hcana window is. It can easily be improved if needed. 
  
   for(Long64_t i=0; i<nentries; i++)
     {
       T->GetEntry(i);  
       
+      //C.Y. Feb 16, 2022 | added pid cuts for use in "LITE" HIT FILTERING of this section of code
+      
+      pcal = pcal_etrkNorm>etrknrm_low_cut;
+      pngcer = pngcer_npeSum>npngcer_npeSum_low_cut;
+      pdctrk = pdc_ntrack>0.0; 
+      betaCut = beta>betanotrack_low_cut&& beta<betanotrack_hi_cut;
+      pid_pelec = pcal&&pngcer&&pdctrk;
+
       //Define some minimum requirements
       Bool_t x1_hit = hod_nhits[0] == 1;
       Bool_t y1_hit = hod_nhits[1] == 1;
@@ -740,10 +1324,20 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
 		      TrackXPos[1]<200&&TrackYPos[1]<200&&
 		      TrackXPos[2]<200&&TrackYPos[2]<200&&
 		      TrackXPos[3]<200&&TrackYPos[3]<200;
-      betaCut=kTRUE;
-      if (cosmic_flag)  betaCut = beta>betanotrack_low_cut&& beta<betanotrack_hi_cut;
-	//require each plane to have ONLY a SINGLE HIT, and hod track coord. to be reasonable (NOT kBig)
-	if (x1_hit&&y1_hit&&x2_hit&&y2_hit&&hodTrk&&betaCut)
+      //betaCut=kTRUE;
+      //if (cosmic_flag)  betaCut = beta>betanotrack_low_cut&& beta<betanotrack_hi_cut;
+      
+      //C.Y. Re-write above beta cut code, same as it is done in other parts of this code
+      if (cosmic_flag) pid_pelec = betaCut&&pdctrk;
+
+      //require each plane to have ONLY a SINGLE HIT, and hod track coord. to be reasonable (NOT kBig)
+      //if (x1_hit&&y1_hit&&x2_hit&&y2_hit&&hodTrk&&betaCut) 
+      
+      // ----------------- "LITE HIT FILTERING (PART 4)" ----------------
+      // C.Y. Feb 26, 2022 | added "LITE" hit filtering 
+      // in hopes of reducing possible background that might be introduced in the LCoeff parameters extracted from the matrix fit.
+      
+      if(pid_pelec && single_hit_flg && hodTrk)
 	  {
 	    
 	    //goodhit: If both ends of a paddle had a tdc hit
@@ -757,12 +1351,19 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
 	    //Loop over hodo planes
 	    for (Int_t npl = 0; npl < PLANES; npl++ )
 	      {
-
+		
 		//loop over paddles
 		for (Int_t bar = 1; bar <= maxPMT[npl]; bar++ )
 		  {
-		    //require good tdc hit on both ends
-		    goodhit[npl] =  TdcTimeTWCorr[npl][0][bar-1]<100.&&TdcTimeTWCorr[npl][1][bar-1]<100.;
+		    
+		    
+		    if (mean_time_flg[i][npl][bar-1]==0) continue; 
+		    
+		    //Dec. 17, 2021 C.Y.  increase the cuts, as it seems after hodo3of4 trigger alignment, this needed to be expanded to at least 125
+		    // Also,  why is it we are only applying a upper cut, and NOT a lower cut?
+		    //require good tdc hit on both ends 
+//HARD CUT NOTICE
+		    goodhit[npl] =  TdcTimeTWCorr[npl][0][bar-1]<125.&&TdcTimeTWCorr[npl][1][bar-1]<125.;
 		    
 		    //count if each plane had good tdc hit
 		    if (goodhit[npl]) {
@@ -782,6 +1383,7 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
 		      
 		      //goodhit counter
 		      cnt = cnt+1;
+		      
 
 		    } //end goodhit requirement
 		    
@@ -815,9 +1417,7 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
 	      t2 = 0.5 * (good_TW_pos[1] +  good_TW_neg[1]);     //Plane 1Y
 	      t3 = 0.5 * (good_TW_pos[2] +  good_TW_neg[2]);     //Plane 2X
 	      t4 = 0.5 * (good_TW_pos[3] +  good_TW_neg[3]);     //Plane 2Y          
-                                           
-	                                                                                                      
-	                                                                                            
+                                           	                                                                                                      	                                                                                            
 	      
 	      //Get all distance/velocity combinations between any two planes
 	      D12 = -sqrt( pow((x2-x1),2) + pow((y2-y1),2) + pow((z2-z1),2));
@@ -919,13 +1519,13 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
     //add each element to the 2d array to be written to a param file
     for (int iplane = 0; iplane<PLANES; iplane++)
       {
-	    for (int ipad = 1; ipad<=maxPMT[iplane]; ipad++)
-	      {
-		LCoeff[iplane][ipad-1] = bVec[ipad+refPad[iplane]-1];
-	      }
+	for (int ipad = 1; ipad<=maxPMT[iplane]; ipad++)
+	  {
+	    LCoeff[iplane][ipad-1] = bVec[ipad+refPad[iplane]-1];
+	  }
       }
-
-
+    
+    
     cout << "Writing to Parameter File . . . " << endl;
     outPARAM << "" << endl;
     outPARAM << "" << endl;
@@ -947,6 +1547,256 @@ void fitHodoCalib(TString filename,Int_t runNUM,Bool_t cosmic_flag=kFALSE)
 	  }
 	
       }
- 
+
+
+    //============================================================
+    // C.Y. Jan 22, 2022 | CALCULATE BETA IN THE CALIBRATION CODE
+    //============================================================
+
+    //Define useful varibales for beta calculation
+    Double_t scinTrnsCoord, scinLongCoord;
+    Double_t pathp, pathn;
+    Double_t tw_corr_pos, tw_corr_neg;
+    Double_t timep, timen;
+    Double_t adcamp_pos, adcamp_neg;
+    Double_t scin_pos_time, scin_neg_time, scin_time;
+    Double_t scin_sigma;
+    Double_t zPosition;
+    Double_t scinWeight;
+   
+    // weighted
+    Double_t sumW;
+    Double_t sumT;
+    Double_t sumZ;
+    Double_t sumZZ;
+    Double_t sumTZ;
+
+    Double_t tmp;
+    Double_t tmpDenom;
+    Double_t pathNorm;
+    Double_t beta_calib;
+
+    // un-weighted
+    Double_t sumW_1;
+    Double_t sumT_1;
+    Double_t sumZ_1; 
+    Double_t sumZZ_1; 
+    Double_t sumTZ_1; 
+    Double_t tmp_1; 
+    Double_t tmpDenom_1; 
+    Double_t beta_calib_1; 
+
+
+    //Get hodo calibe parameters
+    Double_t fTdc_Thrs =  1200.0; // mV
+    Double_t fHodoPos_c2[PLANES][21]   = {0.0};  // "pc2_Pos"
+    Double_t fHodoNeg_c2[PLANES][21]   = {0.0}; // "pc2_Neg"
+    Double_t fHodo_LCoeff[PLANES][21]  = {0.0};
+    Double_t fHodoVelFit[PLANES][21]   = {0.0};
+    Double_t fHodoCableFit[PLANES][21] = {0.0};
+
+    // Declare useful histograms to store calibrated beta
+    TH1F *H_beta_calib_weighted = new TH1F("H_beta_calib_weighted", "Hodoscope Beta (w/Track + Weight) Calibrated", 100, 0., 1.5);
+    TH1F *H_beta_calib_unweighted = new TH1F("H_beta_calib_unweighted", "Hodoscope Beta (w/Track + Weight=1) Calibrated", 100, 0., 1.5);
+
     
+    for(Int_t npl=0; npl < PLANES; npl++)
+      {
+	for(Int_t ipad=0; ipad<21; ipad++)
+	  {
+	    
+	    // Get TW parameters from the standard param file that gets read by HCANA
+	    fHodoPos_c2[npl][ipad]   = GetParam("../../PARAM/SHMS/HODO/phodo_TWcalib.param", "pc2_Pos", npl, ipad, 21 );
+	    fHodoNeg_c2[npl][ipad]   = GetParam("../../PARAM/SHMS/HODO/phodo_TWcalib.param", "pc2_Neg", npl, ipad, 21 );
+	    fHodo_LCoeff[npl][ipad]  = LCoeff[npl][ipad];
+	    fHodoVelFit[npl][ipad]   = phodo_velArr[npl][ipad];
+	    fHodoCableFit[npl][ipad] = phodo_cableArr[npl][ipad];
+	    
+	  }
+	
+      }
+    
+    // NOTE: This part of the code will focus on using the hodo parameter files optained so far, and calculate the beta, exactly as it is calculated in hcana/src/THcHodoscope.cxx
+    // This is in the testing phase . . . until commented otherwise
+
+    
+    cout << "Calculating Hodoscope Beta . . . " << endl;
+    // loop over each entry to calculate beta
+    for(Long64_t i=0; i<nentries; i++)
+      {
+	
+	T->GetEntry(i);
+	
+	// --------- "HIT FILTERING LITE (PART 5) ------------"
+	pcal = pcal_etrkNorm>etrknrm_low_cut;
+	pngcer = pngcer_npeSum>npngcer_npeSum_low_cut;
+	pdctrk = pdc_ntrack>0.0; 
+	betaCut = beta>betanotrack_low_cut&& beta<betanotrack_hi_cut;
+	pid_pelec = pcal&&pngcer&&pdctrk;
+	
+	if (cosmic_flag)  pid_pelec = betaCut&&pdctrk; 
+
+	 //apply (single-hit + PID) per plane
+	if(pid_pelec && single_hit_flg) { 
+       
+
+	//reset counters                                                                                                                                      
+	sumW = 0.;                                                                                                                              
+	sumT = 0.;                                                                                                                                              
+	sumZ = 0.;                                                                                                                                                 
+	sumZZ = 0.;                                                                                                                                           
+	sumTZ = 0.; 
+
+	sumW_1 = 0.;                                                                                                               
+        sumT_1 = 0.;                                                                                                                     
+        sumZ_1 = 0.;                                                                                                                            
+        sumZZ_1 = 0.;                                                                                                                                 
+        sumTZ_1 = 0.;  
+
+	//Loop over hodo planes
+	for (Int_t npl = 0; npl < PLANES; npl++ )
+	  {
+	   
+
+	    // ------- define scin Coord. (same as in THcHodoscope.cxx) -----
+	    if ( ( npl == 0 ) || ( npl == 2 ) )
+	      { 
+		scinTrnsCoord = TrackXPos[npl];
+		scinLongCoord = TrackYPos[npl];
+	      }
+	    else if ( ( npl == 1 ) || ( npl == 3 ) )
+	      { 
+		scinTrnsCoord = TrackYPos[npl];
+		scinLongCoord = TrackXPos[npl];
+	      }
+	    else { return -1; }
+	    
+	    // --------------------------------------------------------------
+	    
+	  
+	    //loop over pmt
+	    for (Int_t ipmt = 0; ipmt < maxPMT[npl]; ipmt++ )
+	      {
+		
+		if (mean_time_flg[i][npl][ipmt]==0) continue; //guarantee tdc meantime is within +/- nSig cut
+
+
+		//require finite tdc times at both ends of a paddle
+	      
+		//PMT fADC Pulse Amplitude (mV)
+		adcamp_pos = AdcPulseAmp[npl][0][ipmt];
+		adcamp_neg = AdcPulseAmp[npl][1][ipmt];
+
+		//PMT TDC Time Time-Walk Uncorrected
+		timep = TdcTimeUnCorr[npl][0][ipmt];
+		timen = TdcTimeUnCorr[npl][1][ipmt];
+		
+		
+		pathp=scinLongCoord;
+		pathn=scinLongCoord;
+		
+		
+		// apply time-walk correction
+		tw_corr_pos = 1./pow(adcamp_pos/fTdc_Thrs,fHodoPos_c2[npl][ipmt]) -  1./pow(200./fTdc_Thrs, fHodoPos_c2[npl][ipmt]);
+		timep += -tw_corr_pos + fHodo_LCoeff[npl][ipmt]+ pathp/fHodoVelFit[npl][ipmt];		 
+		scin_pos_time = timep;
+		
+		
+		tw_corr_neg= 1./pow(adcamp_neg/fTdc_Thrs,fHodoNeg_c2[npl][ipmt]) -  1./pow(200./fTdc_Thrs, fHodoNeg_c2[npl][ipmt]);              
+		timen += -tw_corr_neg- 2*fHodoCableFit[npl][ipmt] + fHodo_LCoeff[npl][ipmt]- pathn/fHodoVelFit[npl][ipmt];
+		scin_neg_time = timen;
+	     
+	
+		//average corrected tdc time
+		scin_time  = ( scin_pos_time + scin_neg_time ) / 2.;
+		scin_sigma = phodo_sigArr[npl][ipmt];
+		scinWeight = 1. / ( scin_sigma * scin_sigma );
+		
+
+		zPosition = z[npl][ipmt];
+
+	     
+		//sum over all paddle hits per evntry (since we currently require single-hit per plane, and 4-plane hits, we will alawys sum up to 4)
+		sumW  += scinWeight;
+		sumT  += scinWeight * scin_time;
+		sumZ  += scinWeight * zPosition;
+		sumZZ += scinWeight * ( zPosition * zPosition );
+		sumTZ += scinWeight * zPosition * scin_time;
+		
+		tmp = sumW * sumZZ - sumZ * sumZ;
+		tmpDenom = sumW * sumTZ - sumZ * sumT;
+		
+		sumW_1  += 1;    
+                sumT_1  += 1 * scin_time;                                                                                         
+                sumZ_1  += 1 * zPosition;                                                                                                                  
+                sumZZ_1 += 1 * ( zPosition * zPosition );                                                                                       
+                sumTZ_1 += 1 * zPosition * scin_time;                                                                                              
+                                                                                                                                                          
+                tmp_1 = sumW_1 * sumZZ_1 - sumZ_1 * sumZ_1;                                                                                    
+                tmpDenom_1 = sumW_1 * sumTZ_1 - sumZ_1 * sumT_1;
+        
+  
+	      } //END paddle loop
+
+	  } // END plane loop
+	
+    
+	if (  TMath::Abs(tmpDenom)  > ( 1 / 10000000000.0 ) ) {
+	  
+	  //cout << "==== TMath::Abs( tmpDenom ) > ( 1 / 10000000000.0 ) ===" << endl;
+	  beta_calib = tmp/tmpDenom;
+	  beta_calib_1 = tmp_1/tmpDenom_1;
+	 
+	  
+		
+	  pathNorm = TMath::Sqrt( 1. + (pdc_xpfp * pdc_xpfp) +  (pdc_ypfp * pdc_ypfp) );
+	  
+	  // Take angle into account
+	  beta_calib = beta_calib / pathNorm;
+	  beta_calib_1 = beta_calib_1 / pathNorm;
+	  //cout << "beta_calib / pathNorm = " << printf("%f", (beta_calib/pathNorm)) << endl;
+	  beta_calib = beta_calib / 29.979;    // velocity / c
+	  beta_calib_1 = beta_calib_1 / 29.979; 
+	  
+	
+	  //Fill weighted histograms
+	  H_beta_calib_weighted->Fill(beta_calib);
+	  H_beta_calib_unweighted->Fill(beta_calib_1);
+	}
+	
+	} //end pid_pelec && single_hit_flg cut
+	
+	cout << std::setprecision(2) << double(i) / nentries * 100. << "  % " << std::flush << "\r";
+	
+      } // end entry loop
+    
+    beta_calibWeighted_canv->cd();
+    H_beta_calib_weighted->Draw();
+    
+    beta_calibUnweighted_canv->cd(); 
+    H_beta_calib_unweighted->Draw(); 
+    
+    //Write Histograms to ROOT file                                                                                                        
+    outROOT->Write();                                                                                                                       
+    outROOT->Close();
+    
+    // de-allocate memory of  3d dynamic array
+    for(int i = 0; i < nentries; i++){
+      
+      for(int j = 0; j < PLANES; j++){ 
+	
+	delete[] mean_time_flg[i][j];                                                                                                 
+	
+      }
+
+      delete[] mean_time_flg[i];
+    }
+    
+    delete[] mean_time_flg;
+
+    // Calculate the analysis rate    
+    t = clock() - t;  
+    printf ("The Analysis Took %.1f seconds (%.1f min.) \n", ((float) t) / CLOCKS_PER_SEC, ((float) t) / CLOCKS_PER_SEC/60.);  
+   
+
 }

--- a/CALIBRATION/shms_hodo_calib/hallc_parse_utils.h
+++ b/CALIBRATION/shms_hodo_calib/hallc_parse_utils.h
@@ -1,0 +1,66 @@
+#ifndef HALLC_PARSE_UTILS_H
+#define HALLC_PARSE_UTILS_H
+#include "parse_utils.h"
+
+/*
+  Author: C. Yero
+  Date: Jan 22, 2022 
+  
+  Brief: This header file is intended to have general utility functions for Hall C software work/analysis.
+  I have created the first function,  and other users/staff are also welcomed to expand and add other useful
+  functions.
+
+*/
+
+
+//_______________________________________________________________________________________________________________
+Double_t GetParam(string fname="", string param_name="", int col_idx=-1, int row_idx=-1, int row_idx_max=-1 )
+{
+
+  /*
+    Brief: This function is intended to facilitate parameter readout of the standard Hall C format:
+
+    where, val_(row,col) is the numerical value of the parameter at (row index, column, index)
+    
+    ; col_idx     0        1       2    ->         .    col_idx_max 
+    param_name = val_(01),  val_(02),  val_(03), . . .  val_(0, col_idx_max)
+                 val_(10),  val_(11),  val_(12), . . . 
+		 .           .
+    		 .                     .
+		 .                               .
+		 val_(row_idx_max, 0), . . . . .. . . . val(row_idx_max, col_idx_max)
+  
+   Typical examples of these parameter format structuca can be found on: 
+   1) hallc_replay/PARAM/SHMS/HODO/phodo_TWcalib.param   or 
+   2  hallc_replay/PARAM/HMS/CAL/hcal_calib.param    etc.   
+   ( you get the idea . . . )
+   
+   Input Parameter Definitions:
+   
+   fname       : parameter file name containing the parameters to be extracted 
+   param_name  : actual parameter name as is present in the parameter file
+   col_idx     : column index, starting from 0
+   row_idx     : row index, starting from 0
+   row_idx_max : maximum row index, for example for SHMS Hodo Quartz Plane: row_idx_max = 21
+
+  */
+  
+  Double_t param_val=-1;
+  
+  if(row_idx==0){
+    //cout << parse_line(split(FindString(param_name.c_str(), fname.c_str(), true, row_idx_max)[row_idx], '=')[1], ',')[col_idx] << endl ;
+    param_val = stod(parse_line(split(FindString(param_name.c_str(), fname.c_str(), true, row_idx_max)[row_idx], '=')[1], ',')[col_idx]);
+    return param_val;
+  }
+  
+  else if(row_idx>0){
+    //cout << parse_line(FindString(param_name.c_str(), fname.c_str(), true, row_idx_max)[row_idx], ',')[col_idx] << endl ;
+    param_val = stod(parse_line(FindString(param_name.c_str(), fname.c_str(), true, row_idx_max)[row_idx], ',')[col_idx]);
+    return param_val;
+  }
+
+  else return param_val;
+  
+}
+
+#endif

--- a/CALIBRATION/shms_hodo_calib/parse_utils.h
+++ b/CALIBRATION/shms_hodo_calib/parse_utils.h
@@ -1,0 +1,202 @@
+#ifndef PARSE_UTILS_H
+#define PARSE_UTILS_H
+
+/*
+  Author: C. Yero
+  Date: Jan 22, 2022 
+ */
+
+//The pasrse_utils.h header file contains useful functions for C++ string parsing
+
+
+//------------------------START UTILITIES FUNCTIONS----------------------------
+
+
+//_______________________________________________________________________________
+vector<string> parse_line(string my_str, char del)
+{
+
+  /*
+    Brief: This method reads in a string and parses it 
+    based on the specified delimiter (del). A parsed
+    vector is returned, whose elements are the values
+    previously separated by the delimiter
+    
+   */
+  
+  vector<string> parsed;
+  stringstream s_stream(my_str); //create string stream from the string
+
+  while(s_stream.good()) {
+
+    string substr;
+    getline(s_stream, substr, del); //get first string delimited by comma
+    parsed.push_back(substr);
+
+  }
+
+
+  return parsed;
+}
+
+//_______________________________________________________________________________
+string getString(char x)
+{
+  //method to convert a character to a string
+  string s(1,x);
+  return s;
+}
+
+//_______________________________________________________________________________
+vector <string> split(string str, char del=':')
+{
+  
+  //method to split a string into a vetor of strings separated by a delimiter del
+  //Returns a vector of strings, whose elements are separated by the delimiter del.
+  
+  string temp1, temp2;
+  
+  vector <string> parse_word;
+  int del_pos;  //delimiter position
+  
+  for (int i=0; i < str.size(); i++){
+    
+    //Get position of delimiter
+    if(str[i]==del){
+      del_pos = i;
+    }
+    
+  }
+  
+  for (int i=0; i < str.size(); i++){
+    
+    //append char to a string for char left of the delimiter
+    if(i<del_pos){
+      temp1.append(getString(str[i]));
+    }      
+    
+    //append char to a string for char right of the delimiter
+    else if(i>del_pos){
+      temp2.append(getString(str[i]));
+    }
+    
+  }
+  parse_word.push_back(temp1);
+  parse_word.push_back(temp2);
+  
+  return parse_word;
+}
+
+//_______________________________________________________________________________
+vector <string> FindString(string keyword, string fname, bool multi_line=false, int line_max=-1)
+{
+  
+  //Method: Finds string keyword in a given txt file. 
+  //Returns the lines (stored in a vector) in which the keyword was found. Lines are counted from 0. 
+
+  /*
+    DEFINITION OF INPUT FUNCTION PARAMETERS:
+    'keyword'    : the actual keyword the user needs to find in the file
+    'fname'      : the filename full path where the keyword can be found
+    'multi_line' : boolean flag that gives the option to read not only the line where the keyword is found,
+    but also the subsequent lines below the keyword line.
+    'line_max' : maximum number of lines to be read, including the line where the keyword is found. 
+    For example, if line_max = 10, the first 10 lines (including the keyword line) will be stored into the line_found vector
+    
+    Example of usage for:
+
+    ---multi-line parameters---
+    
+    FindString("keyword_name", "path/to/filename.txt", true, 3)[0]
+    FindString("keyword_name", "path/to/filename.txt", true, 3)[1]
+    FindString("keyword_name", "path/to/filename.txt", true, 3)[2]
+    
+    --single-line parameter---
+    FindString("keyword_name", "path/to/filename.txt")[0]
+  
+  */
+  
+  ifstream ifile(fname);
+  
+  vector <string> line_found; //vector to store in which lines was the keyword found
+
+  int line_fnd = -1;
+  int line_cnt = 0;
+  string line;                  //line string to read
+  
+  int found = -1; //position of found keyword
+  
+  while(getline(ifile, line))
+    {
+      //Check 1st character of found string
+      TString cmt = line[0];
+      
+      found = line.find(keyword);
+      
+      if(found<0||found>1000){found=-1;} //not found
+      if(cmt==";" || cmt=="#" || cmt=="!") {found=-1;}  //Found commented line. So Skip (You can add more definition of comments)
+
+      if(found!=-1){
+	//cout << "position of line found = " << line_cnt <<  endl;
+	line_fnd = line_cnt;  //store line number where the keyword was found
+	//line_found.push_back(line);
+	
+      } //end if statement
+
+      //C.Y. Jan 22 || potentially read subsequent lines (in case of multi-line paramerers)
+      if(multi_line){
+	// read only single line, where the keyword was found
+	if ( (line_fnd!=-1) and (line_cnt<line_fnd+line_max) ){
+	  //cout << "line_cnt = " << line_cnt << ", line_fnd = " << line_fnd << endl;     
+	  //cout << "line --> " << line << endl;
+	  line_found.push_back(line);
+	}
+      }
+      
+      // Only read single-line keyword 
+      else if (line_fnd==line_cnt){
+	line_found.push_back(line);
+      }
+
+      
+      // increment line counter
+      line_cnt++;
+      
+    } //end readlines
+
+  return line_found;
+
+}
+
+//_______________________________________________________________________________
+string& ltrim(std::string& s)
+{
+  auto it = std::find_if(s.begin(), s.end(),
+			 [](char c) {
+			   return !std::isspace<char>(c, std::locale::classic());
+			 });
+  s.erase(s.begin(), it);
+  return s;
+}
+
+//_______________________________________________________________________________
+string& rtrim(std::string& s)
+{
+  auto it = std::find_if(s.rbegin(), s.rend(),
+						[](char c) {
+			   return !std::isspace<char>(c, std::locale::classic());
+			 });
+  s.erase(it.base(), s.end());
+  return s;
+}
+
+//_______________________________________________________________________________
+string& trim(std::string& s)
+{
+  return ltrim(rtrim(s));
+}
+
+//--------------------------END UTILITIES FUNCTIONS----------------------------
+
+
+#endif

--- a/CALIBRATION/shms_hodo_calib/timeWalkHistos.C
+++ b/CALIBRATION/shms_hodo_calib/timeWalkHistos.C
@@ -1,6 +1,6 @@
 // Macro to generate time-walk histograms for the hodoscopes
 // Author: Eric Pooser, pooser@jlab.org
-
+// Changes made by/Jacob Murphy (Ohio U) and Nathan Heinrich (UR) 2021/12/08, including new plotting bounds and fit style
 #include <time.h>
 #include <TSystem.h>
 #include <TString.h>
@@ -45,7 +45,7 @@ static const TString detec = "hod";
 static const TString trig  = "T";
 static const TString shms  = "shms";
 
-static const UInt_t  nbars[nPlanes]        = {13, 13, 14, 21};
+static const UInt_t  nbars[nPlanes]        = {13, 13, 14, 18};
 static const TString planeNames[nPlanes]   = {"1x", "1y", "2x", "2y"};
 static const TString sideNames[nSides]     = {"pos", "neg"};
 static const TString signalNames[nSignals] = {"Adc", "Tdc"};
@@ -58,18 +58,20 @@ static const Double_t adcDynamicRange = 1000.0;                   // Units of mV
 static const Double_t nAdcChan        = 4096.0;                   // Units of ADC channels
 static const Double_t adcChanTomV     = adcDynamicRange/nAdcChan; // Units of mV/ADC Chan
 
-static const Double_t hodoPulseAmpCutLow     = 10.0;   // Units of mV
+static const Double_t hodoPulseAmpCutLow     = 15.0;   // Units of mV
 static const Double_t hodoPulseAmpCutHigh    = 1000.0; // Units of mV
-static const Double_t refAdcPulseAmpCutLow   = 50.0;   // Units of mV
-static const Double_t refAdcPulseAmpCutHigh  = 60.0;   // Units of mV
-static const Double_t refAdcPulseTimeCutLow  = 210.0;  // Units of ns
-static const Double_t refAdcPulseTimeCutHigh = 225.0;  // Units of ns
-static const Double_t adcTdcTimeDiffCutLow   = -100.0; // Units of ns
+static const Double_t refAdcPulseAmpCutLow   = 40.0;   // Units of mV
+static const Double_t refAdcPulseAmpCutHigh  = 70.0;   // Units of mV
+static const Double_t refAdcPulseTimeCutLow  = 300.0;  // Units of ns
+static const Double_t refAdcPulseTimeCutHigh = 370.0;  // Units of ns
+static const Double_t adcTdcTimeDiffCutLow   = 0.0; // Units of ns
 static const Double_t adcTdcTimeDiffCutHigh  = 100.0;  // Units of ns
-static const Double_t calEtotCutVal          = 2.0;  // Units of GeV
-static const Double_t cerNpeSumCutVal        = 1.5;    // Units of NPE
+static const Double_t calEtotnormCutVal      = 0.7;    // Units of Normalized energy
+static const Double_t cerNpeSumCutVal        = 0.5;    // Units of NPE in aerogel
 // static const Double_t adcTdcTimeDiffCutLow   = -6000.0;  // Units of ns
 // static const Double_t adcTdcTimeDiffCutHigh  = 1000.0;  // Units of ns
+
+static const bool TimeWalkRangeSet = false; // this will determine if the TDC ADC Time Diff walk is done per plane or set with the adcTdcTimeDiffCutLow/High variables 
 
 static const Double_t fontSize = 0.04;
 
@@ -122,15 +124,14 @@ Int_t numAdcHits, numTdcHits;
 
 Double_t adcErrorFlag, adcPulseTimeRaw, adcPulseTime, adcPulseAmp;
 Double_t tdcTimeRaw, tdcTime, adcTdcTimeDiff;
-Double_t calEtot, cerNpeSum;
+Double_t calEtotnorm, cerNpeSum;
 
 Bool_t adcRefMultiplicityCut, adcRefPulseAmpCut, adcRefPulseTimeCut;
 Bool_t edtmCut, adcErrorFlagCut, adcAndTdcHitCut;
 Bool_t adcPulseAmpCut, adcTdcTimeDiffCut;
-Bool_t calEtotCut, cerNpeSumCut;
+Bool_t calEtotnormCut, cerNpeSumCut;
 
 void generatePlots(UInt_t iplane, UInt_t iside, UInt_t ipaddle) {
-
   // Create trigger aparatus directory
   trigRawDir = dynamic_cast <TDirectory*> (outFile->Get("trigAppRaw"));
   if (!trigRawDir) {trigRawDir = outFile->mkdir("trigAppRaw"); trigRawDir->cd();}
@@ -194,8 +195,19 @@ void generatePlots(UInt_t iplane, UInt_t iside, UInt_t ipaddle) {
   if (!adcTdcTimeDiffWalkDir[iplane][iside]) {adcTdcTimeDiffWalkDir[iplane][iside] = sideUncalibDir[iplane][iside]->mkdir("adcTdcTimeDiffWalk"); adcTdcTimeDiffWalkDir[iplane][iside]->cd();}
   else (outFile->cd("hodoUncalib/"+planeNames[iplane]+"/"+sideNames[iside]+"/adcTdcTimeDiffWalk"));
   // Book histos
-  if (!h2_adcTdcTimeDiffWalk[iplane][iside][ipaddle]) h2_adcTdcTimeDiffWalk[iplane][iside][ipaddle] = new TH2F(Form("h2_adcTdcTimeDiffWalk_paddle_%d", ipaddle+1), "TDC-ADC Time vs. Pulse Amp Plane "+planeNames[iplane]+" Side "+sideNames[iside]+Form(" Paddle %d", ipaddle+1)+"; Pulse Amplitude (mV) / 1 mV;  TDC-ADC Time (ns) / 100 ps", 1000, 0, 1000, 500, -20, 30);
-  
+  if (!h2_adcTdcTimeDiffWalk[iplane][iside][ipaddle] && !TimeWalkRangeSet){ // NH 2021 11 26 changed this so that each plane could have the y-range set seperately
+    if (iplane == 0)
+      h2_adcTdcTimeDiffWalk[iplane][iside][ipaddle] = new TH2F(Form("h2_adcTdcTimeDiffWalk_paddle_%d", ipaddle+1), "TDC-ADC Time vs. Pulse Amp Plane "+planeNames[iplane]+" Side "+sideNames[iside]+Form(" Paddle %d", ipaddle+1)+"; Pulse Amplitude (mV) / 1 mV;  TDC-ADC Time (ns) / 100 ps", 500, 0, 500, 1500, 15, 35);
+    if(iplane == 1)
+      h2_adcTdcTimeDiffWalk[iplane][iside][ipaddle] = new TH2F(Form("h2_adcTdcTimeDiffWalk_paddle_%d", ipaddle+1), "TDC-ADC Time vs. Pulse Amp Plane "+planeNames[iplane]+" Side "+sideNames[iside]+Form(" Paddle %d", ipaddle+1)+"; Pulse Amplitude (mV) / 1 mV;  TDC-ADC Time (ns) / 100 ps", 500, 0, 500, 1500, 20, 40);
+    if(iplane == 2)
+      h2_adcTdcTimeDiffWalk[iplane][iside][ipaddle] = new TH2F(Form("h2_adcTdcTimeDiffWalk_paddle_%d", ipaddle+1), "TDC-ADC Time vs. Pulse Amp Plane "+planeNames[iplane]+" Side "+sideNames[iside]+Form(" Paddle %d", ipaddle+1)+"; Pulse Amplitude (mV) / 1 mV;  TDC-ADC Time (ns) / 100 ps", 500, 0, 500, 1500, 15, 35);
+    if(iplane == 3)
+      h2_adcTdcTimeDiffWalk[iplane][iside][ipaddle] = new TH2F(Form("h2_adcTdcTimeDiffWalk_paddle_%d", ipaddle+1), "TDC-ADC Time vs. Pulse Amp Plane "+planeNames[iplane]+" Side "+sideNames[iside]+Form(" Paddle %d", ipaddle+1)+"; Pulse Amplitude (mV) / 1 mV;  TDC-ADC Time (ns) / 100 ps", 500, 0, 500, 1500, 33, 53);
+  }else{
+    if(!h2_adcTdcTimeDiffWalk[iplane][iside][ipaddle] && TimeWalkRangeSet)
+      h2_adcTdcTimeDiffWalk[iplane][iside][ipaddle] = new TH2F(Form("h2_adcTdcTimeDiffWalk_paddle_%d", ipaddle+1), "TDC-ADC Time vs. Pulse Amp Plane "+planeNames[iplane]+" Side "+sideNames[iside]+Form(" Paddle %d", ipaddle+1)+"; Pulse Amplitude (mV) / 1 mV;  TDC-ADC Time (ns) / 100 ps", 500, 0, 500, 1500, adcTdcTimeDiffCutLow, adcTdcTimeDiffCutHigh);
+  }
 } // generatePlots()
 
 void timeWalkHistos(TString inputname, Int_t runNum, string SPEC_flg) {  //SPEC_flg--> "shms" or "coin"
@@ -215,8 +227,8 @@ void timeWalkHistos(TString inputname, Int_t runNum, string SPEC_flg) {  //SPEC_
     
   replayFile = new TFile(inputname, "READ");
   // replayFile = new TFile(Form("ROOTfiles/shms_coin_replay_production_%d_-1.root", runNum), "READ");
-   
-  outFile    = new TFile("timeWalkHistos.root", "RECREATE");
+  TString outFileName = Form("timeWalkHistos_%d.root", runNum ); // SK 13/5/19 - new .root output for each run tested                                                                                             
+  outFile    = new TFile(outFileName, "RECREATE");
   // Obtain the tree
   rawDataTree = dynamic_cast <TTree*> (replayFile->Get("T"));
 
@@ -226,6 +238,27 @@ void timeWalkHistos(TString inputname, Int_t runNum, string SPEC_flg) {  //SPEC_
   Double_t phod_2xnhits;
   Double_t phod_2ynhits;
 
+  //C.Y. Dec 21, 2021 | Variables for Good ADC,TDC Hits per plane side (this will be used to require 2-ended PMT hits)
+  Double_t phod_1x_posAdcHits;
+  Double_t phod_1x_negAdcHits;
+  Double_t phod_1x_posTdcHits;
+  Double_t phod_1x_negTdcHits;
+
+  Double_t phod_1y_posAdcHits;
+  Double_t phod_1y_negAdcHits;
+  Double_t phod_1y_posTdcHits;
+  Double_t phod_1y_negTdcHits;
+
+  Double_t phod_2x_posAdcHits;
+  Double_t phod_2x_negAdcHits;
+  Double_t phod_2x_posTdcHits;
+  Double_t phod_2x_negTdcHits;
+
+  Double_t phod_2y_posAdcHits;
+  Double_t phod_2y_negAdcHits;
+  Double_t phod_2y_posTdcHits;
+  Double_t phod_2y_negTdcHits;
+  
   // Acquire the trigger apparatus data
   rawDataTree->SetBranchAddress(Form("T.%s.pFADC_TREF_ROC2_adcPulseTimeRaw", SPEC_flg.c_str()), &refAdcPulseTimeRaw);
   rawDataTree->SetBranchAddress(Form("T.%s.pFADC_TREF_ROC2_adcPulseAmp", SPEC_flg.c_str()),     &refAdcPulseAmp);
@@ -233,16 +266,40 @@ void timeWalkHistos(TString inputname, Int_t runNum, string SPEC_flg) {  //SPEC_
   rawDataTree->SetBranchAddress(Form("T.%s.pT1_tdcTimeRaw", SPEC_flg.c_str()), &refT1TdcTimeRaw);
   rawDataTree->SetBranchAddress(Form("T.%s.pT2_tdcTimeRaw", SPEC_flg.c_str()), &refT2TdcTimeRaw);
   rawDataTree->SetBranchAddress(Form("T.%s.pT3_tdcTimeRaw", SPEC_flg.c_str()), &refT3TdcTimeRaw);
-  // rawDataTree->SetBranchAddress("P.cal.etot", &calEtot);
-  // rawDataTree->SetBranchAddress("P.ngcer.npeSum", &cerNpeSum);
+
+  //C.Y. Dec 21. 2021 | Suggestion: These types of cuts should be placed externaly to let the uset
+  // select the appropiate cut based on their experiment
+  rawDataTree->SetBranchAddress("P.cal.etracknorm", &calEtotnorm);
+  rawDataTree->SetBranchAddress("P.hgcer.npeSum", &cerNpeSum);
+  //rawDataTree->SetBranchAddress("P.ngcer.npeSum", &cerNpeSum);
 
   rawDataTree->SetBranchAddress("P.hod.1x.nhits", &phod_1xnhits);
   rawDataTree->SetBranchAddress("P.hod.1y.nhits", &phod_1ynhits);
   rawDataTree->SetBranchAddress("P.hod.2x.nhits", &phod_2xnhits);
   rawDataTree->SetBranchAddress("P.hod.2y.nhits", &phod_2ynhits);
 
- 
+  //C.Y. Dec 21, 2021 | Added variable for total number of good ADC, TDC hits per plane side 
+  rawDataTree->SetBranchAddress("P.hod.1x.totNumGoodPosAdcHits", &phod_1x_posAdcHits);
+  rawDataTree->SetBranchAddress("P.hod.1x.totNumGoodNegAdcHits", &phod_1x_negAdcHits);
+  rawDataTree->SetBranchAddress("P.hod.1x.totNumGoodPosTdcHits", &phod_1x_posTdcHits);
+  rawDataTree->SetBranchAddress("P.hod.1x.totNumGoodNegTdcHits", &phod_1x_negTdcHits);
 
+  rawDataTree->SetBranchAddress("P.hod.1y.totNumGoodPosAdcHits", &phod_1y_posAdcHits);
+  rawDataTree->SetBranchAddress("P.hod.1y.totNumGoodNegAdcHits", &phod_1y_negAdcHits);
+  rawDataTree->SetBranchAddress("P.hod.1y.totNumGoodPosTdcHits", &phod_1y_posTdcHits);
+  rawDataTree->SetBranchAddress("P.hod.1y.totNumGoodNegTdcHits", &phod_1y_negTdcHits);
+
+  rawDataTree->SetBranchAddress("P.hod.2x.totNumGoodPosAdcHits", &phod_2x_posAdcHits);
+  rawDataTree->SetBranchAddress("P.hod.2x.totNumGoodNegAdcHits", &phod_2x_negAdcHits);
+  rawDataTree->SetBranchAddress("P.hod.2x.totNumGoodPosTdcHits", &phod_2x_posTdcHits);
+  rawDataTree->SetBranchAddress("P.hod.2x.totNumGoodNegTdcHits", &phod_2x_negTdcHits);
+
+  rawDataTree->SetBranchAddress("P.hod.2y.totNumGoodPosAdcHits", &phod_2y_posAdcHits);
+  rawDataTree->SetBranchAddress("P.hod.2y.totNumGoodNegAdcHits", &phod_2y_negAdcHits);
+  rawDataTree->SetBranchAddress("P.hod.2y.totNumGoodPosTdcHits", &phod_2y_posTdcHits);
+  rawDataTree->SetBranchAddress("P.hod.2y.totNumGoodNegTdcHits", &phod_2y_negTdcHits);
+
+				
 // Loop over the planes, sides, signals, leafs, and fill data arrays
   for(UInt_t iplane = 0; iplane < nPlanes; iplane++) {
     
@@ -304,10 +361,14 @@ void timeWalkHistos(TString inputname, Int_t runNum, string SPEC_flg) {  //SPEC_
   } // Plane loop
 
   Bool_t good_hits;
+  Bool_t good_two_ended_hits_1x;
+  Bool_t good_two_ended_hits_1y;
+  Bool_t good_two_ended_hits_2x;
+  Bool_t good_two_ended_hits_2y;
   
     // Loop over the events and fill histograms
-  nentries = rawDataTree->GetEntries();
-  //nentries = ;
+  nentries = 10000; //rawDataTree->GetEntries();
+  
   cout << "\n******************************************"    << endl;
   cout << nentries << " Events Will Be Processed"           << endl;
   cout << "******************************************\n"    << endl;
@@ -316,12 +377,39 @@ void timeWalkHistos(TString inputname, Int_t runNum, string SPEC_flg) {  //SPEC_
     rawDataTree->GetEntry(ievent);
   
     good_hits = phod_1xnhits==1&&phod_1ynhits==1&&phod_2xnhits==1&&phod_2ynhits==1;
+    
+    //C.Y. Dec 21, 2021 | Add 2-ended PMT hit requirement for both ADCs and TDCs
+    good_two_ended_hits_1x = phod_1x_posAdcHits==1 && phod_1x_negAdcHits==1 && phod_1x_posTdcHits==1 && phod_1x_negTdcHits==1;
+    good_two_ended_hits_1y = phod_1y_posAdcHits==1 && phod_1y_negAdcHits==1 && phod_1y_posTdcHits==1 && phod_1y_negTdcHits==1;
+    good_two_ended_hits_2x = phod_2x_posAdcHits==1 && phod_2x_negAdcHits==1 && phod_2x_posTdcHits==1 && phod_2x_negTdcHits==1;
+    good_two_ended_hits_2y = phod_2y_posAdcHits==1 && phod_2y_negAdcHits==1 && phod_2y_posTdcHits==1 && phod_2y_negTdcHits==1;
+    
 
     // Fiducial PID cuts
-    //   calEtotCut   = (calEtot   < calEtotCutVal);
-    //cerNpeSumCut = (cerNpeSum < cerNpeSumCutVal);
-    // if (calEtotCut || cerNpeSumCut) continue;
-    if (!good_hits) continue;
+    calEtotnormCut   = (calEtotnorm < calEtotnormCutVal);
+    cerNpeSumCut = (cerNpeSum < cerNpeSumCutVal); // JM 31-10-21: Editing cer cuts for good event selection. Added non-zero requirement
+    if (calEtotnormCut || cerNpeSumCut) continue;
+    
+    //if (!good_hits) continue; 
+    //if (!(good_two_ended_hits_1x && good_two_ended_hits_1y && good_two_ended_hits_2x && good_two_ended_hits_2y)) continue; //C.Y. Added 2-ended hit requirement
+    
+    if (!(good_hits && good_two_ended_hits_1x && good_two_ended_hits_1y && good_two_ended_hits_2x && good_two_ended_hits_2y)) continue; //C.Y. Added 2-ended hit requirement         
+
+    //cout << "evt = " << ievent << endl;
+    //cout << "phod_1xnhits = " << phod_1xnhits << endl;
+    //if(good_two_ended_hits_1x){
+    /*
+    cout << "evt = " << ievent << endl;                                                                                                      
+    cout << "phod_1xnhits = " << phod_1xnhits << endl;  
+    cout << "phod_1x_posAdcHits = " << phod_1x_posAdcHits << endl;                     
+    cout << "phod_1x_negAdcHits = " << phod_1x_negAdcHits << endl;                                                                       
+    cout << "phod_1x_posTdcHits = " << phod_1x_posTdcHits << endl;                                                            
+    cout << "phod_1x_negTdcHits = " << phod_1x_negTdcHits << endl;  
+    cout << "-------" << endl;
+    cout << "" << endl;
+    */
+    //}
+    
     // Fill trigger apparatus histos
     h1_refAdcPulseTimeRaw->Fill(refAdcPulseTimeRaw*adcChanToTime);
     h1_refAdcPulseAmp->Fill(refAdcPulseAmp);
@@ -383,11 +471,11 @@ void timeWalkHistos(TString inputname, Int_t runNum, string SPEC_flg) {  //SPEC_
 	  } // TDC signal
 
 	    // Define cuts
-	  adcRefMultiplicityCut = (refAdcMultiplicity != 1.0);
+	  adcRefMultiplicityCut = (refAdcMultiplicity < 1.0); //cut only zeros
 	  adcRefPulseAmpCut     = (refAdcPulseAmp < refAdcPulseAmpCutLow || refAdcPulseAmp > refAdcPulseAmpCutHigh);
 	  adcRefPulseTimeCut    = (refAdcPulseTimeRaw*adcChanToTime < refAdcPulseTimeCutLow || refAdcPulseTimeRaw*adcChanToTime > refAdcPulseTimeCutHigh);
 	  // Implement cuts
-	  //if (adcRefMultiplicityCut || adcRefPulseAmpCut || adcRefPulseTimeCut) continue;	  
+	  if (adcRefMultiplicityCut || adcRefPulseAmpCut || adcRefPulseTimeCut) continue;	  
 	  // Acquire the hodoscope ADC data objects
 	  if(signalNames[isignal] == "Adc") { 
 	    // Loop over the signals again
@@ -450,6 +538,9 @@ void timeWalkHistos(TString inputname, Int_t runNum, string SPEC_flg) {  //SPEC_
 	} // Signal loop
       } // Side loop
     } // Plane loop
+    
+    //C.Y. Feb 25, 2022 | print the percentage of events analyzed 
+    cout << std::setprecision(2) << double(ievent) / nentries * 100. << "  % " << std::flush << "\r"; 
 
     if (ievent % 100000 == 0 && ievent != 0)
       cout << ievent << " Events Have Been Processed..." << endl;
@@ -462,12 +553,12 @@ void timeWalkHistos(TString inputname, Int_t runNum, string SPEC_flg) {  //SPEC_
 
   // Calculate the analysis rate
   t = clock() - t;
-  printf ("The Analysis Took %.1f seconds \n", ((float) t) / CLOCKS_PER_SEC);
+  printf ("The Analysis Took %.1f seconds (%.1f min.) \n", ((float) t) / CLOCKS_PER_SEC,  ((float) t) / CLOCKS_PER_SEC/60.) ;
   printf ("The Analysis Event Rate Was %.3f kHz \n", (ievent + 1) / (((float) t) / CLOCKS_PER_SEC*1000.));
 
   outFile->Write();
-  //outFile->Close();
+  outFile->Close();
 
   //return 0;
 
-} // time_walk_calib()
+} 

--- a/CALIBRATION/shms_hodo_calib/timeWalkHistos.C
+++ b/CALIBRATION/shms_hodo_calib/timeWalkHistos.C
@@ -367,7 +367,7 @@ void timeWalkHistos(TString inputname, Int_t runNum, string SPEC_flg) {  //SPEC_
   Bool_t good_two_ended_hits_2y;
   
     // Loop over the events and fill histograms
-  nentries = 10000; //rawDataTree->GetEntries();
+  nentries = rawDataTree->GetEntries();
   
   cout << "\n******************************************"    << endl;
   cout << nentries << " Events Will Be Processed"           << endl;


### PR DESCRIPTION
Changes to be committed:
modified:   fitHodoCalib.C
new file:   hallc_parse_utils.h
new file:   parse_utils.h
modified:   timeWalkCalib.C
modified:   timeWalkHistos.C
1) minor improvements to the timeWalkCalib.C to add single hit per plane and get cleaner time-walk distribution for improved fitting
2) minor improvements to the timeWalkHistos.C to save histograms to .png format, (changes were actually made by Jacob Murphy/Nathan Heinrich)
3) major improvements to fitHodoCalib.C to put restrictive contrains on events that are calibrated using the "LITE HIT FILTERING" approach idealized by D. Mack and implemented by me. The are also additional constraints on the velocity parameters to actually write out realistic velocities within a specified range, as well as improved the hodoscope sigma (resolution) parameters. I have also added lines of code to calculate beta from the calibrated parameters, to compare with the beta from HCANA.
4. added parse_utils.h and hallc_parse_utils.h header files which are used to do the beta calculation from within the fitHodoCalib.C code. These header files can also be useful for other applications which need parameter readout from other param files.