### PR TITLE
Fixing README.md for CALIBRATION/ and shms_ngcer_calib

### DIFF
--- a/CALIBRATION/README.md
+++ b/CALIBRATION/README.md
@@ -32,6 +32,4 @@
 
 10. set_peddefault : Contains script to determine the default pedestals for each SHMS and HMS detector.
 
-
-
-
+11. shms_ngcer_calib : Contains script to calibrate the NPE/ADC conversion parameters for SHMS Noble Gas Cerenkov.

--- a/CALIBRATION/shms_ngcer_calib/README.md
+++ b/CALIBRATION/shms_ngcer_calib/README.md
@@ -1,35 +1,19 @@
-# Hall C Calibration Codes
+Cameron Cotton 02/20/23
 
-1. This is the directory containing subdirectories for Hall C calibration codes.
-2. A few of the directories are obsolete. 
-3. Each subdirectory has a README or HOWTO which explains how to run the calibration code.
+This directory contains code used to calibrate the SHMS NGCER detector.
 
-## Obsolete directories
+To run the code, simply be in this directory (shms_ngcer_calib) and type root -l pngcer_calib.C. This will open an interactive root session and begin running the script.
 
-1. hms_dc_calib : old HMS DC Tzero and time-to-distance maps calibration code
-2. shms_dc_calib : old SHMS DC Tzero and time-to-distance maps calibration code
-3. hodo_calib: old hodoscope calibration code used during the 6GeV running
+You will be prompted to enter run number(s), space separated, for the run(s) you would like to use for the calibration. As this code utilizes RDataFrames and runs very quickly, I would suggest using on the order of millions of events for the calibration. Ideally, the runs chosen will have a large fraction of good electrons, and events at that setting should cover all 4 of the Cerenkov's PMTs well. The path from this directory to the corresponding replay files is expected to follow the pattern "../../ROOTfiles/SHMS/CALIBRATION/shms_replay_cer_%i_-1.root" where %i is to be replaced with the run number. Change this if your file naming or directory organization is different.
 
-## Directories
+Once run number(s) are entered, the code will run.
 
-1. bcm_current_map : Contains scripts to create parameter files of the beam current as a function of event number to be used in the code for cutting data according to a beam current cut.
+One common runtime error is that the code cannot find one of the branches it is looking for. If the code cannot find a branch that it is looking for, then that branch is not likely present in the replay file used, and needs to be added. Required Branches: P.cal.etottracknorm P.gtr.dp P.ngcer.goodAdcMult P.ngcer.xAtCer P.ngcer.yAtCer P.ngcer.goodAdcPulseInt
 
-2. bpm_calib : Contains scripts for fitting HARP vs BPM scans and creating a parameter file.
+If it does not find one of the branches, the error message will generally say that it cannot find "P".
 
-3. dc_calib/scripts : Contains scripts for calibrating tzero parameters and time-to-dsitance maps for eithe the HMS or SHMS drift chambers. 
+Once the code finishes running, it will produce 3 windows with diagnostic plots for the user to confirm that the data looks ok. Verify that the fits on the plots of the pulse integral are fitting the peak well. If the correct range is not being fitted, you can manually change it in the code.
 
-4. hms_cal_calib : Contains scripts for calibrating the HMS calorimeter energy/ADC conversion for each block. 
+The calibration constants to be put in the param file will also be printed to the terminal. The calibration constant represents the effective gain of the system, or the conversion factor between the pulse integral and the number of photoelectrons (charge in pC per photoelectron).
 
-5. shms_cal_calib : Contains scripts for calibrating the SHMS calorimeter energy/ADC conversion for each block. 
-
-6. hms_hodo_calib : Contains scripts for calibrating the time offsets for the HMS hodoscope. Creates the time walk correction parameters, time difference between negative-postive PMTs in a paddle and the relative time offsets of the paddles.
-
-7. shms_hodo_calib : Contains scripts for calibrating the time offsets for the SHMS hodoscope. Creates the time walk correction parameters, time difference between negative-postive PMTs in a paddle and the relative time offsets of the paddles.
-
-8. shms_aero_calib : Contains a script to calibrate the NPE/ADC conversion parameters from SPE peaks for the SHMS aerogel.
-
-9. shms_hgcer_calib : Contains scripts to calibrate the NPE/ADC conversion parameters for SHMS Gas Cerenkovs.
-
-10. set_peddefault : Contains script to determine the default pedestals for each SHMS and HMS detector.
-
-11. shms_ngcer_calib : Contains scripts to calibrate the NPE/ADC conversion parameters for the SHMS Noble Gas Cerenkov
+As of 01/11/23, PMT 1 is noisy, so different fit ranges need to be set on those plots. Also, the multiplicity cut should be changed from P.ngcer.goodAdcMult[0]==1 to >=1 as suggested by Mark Jones to deal with this issue.


### PR DESCRIPTION
The README.md for shms_ngcer_calib was overwritten by the README.md for CALIBRATIONS/ at some point, so I corrected that and added shms_ngcer_calib to the list of calibrations in the README.md for CALIBRATIONS/.